### PR TITLE
Fix: Display Plain .mdx Files

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,7 @@
 const path = require('path');
 module.exports = {
   "stories": [
-    "../src/**/*.stories.mdx",
+    "../src/**/*.mdx",
     "../src/**/*.stories.@(js|jsx|ts|tsx)"
   ],
   "addons": [


### PR DESCRIPTION
Currently the `.mdx` files are not displayed.