### PR TITLE
Fix: Build the Package Before Publishing It

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@lion5'
       - run: npm ci
+      - run: npm build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We need to build the package so that a dist folder is generated. This is then referenced in the `package.json` `files` section

Fixes #11 