### PR TITLE
Fix: Use VeeValidate value for Image Preview in `PreviewImageInput.vue`

### DIFF
--- a/src/atoms/inputs/PreviewImageInput/PreviewImageInput.vue
+++ b/src/atoms/inputs/PreviewImageInput/PreviewImageInput.vue
@@ -27,7 +27,11 @@ const emit = defineEmits<{
 }>()
 
 const localName = toRef(props, 'name')
-const { value: selectedImage, errorMessage } = useField<File>(localName)
+const { value: selectedImage, errorMessage } = useField<File>(
+  localName,
+  undefined,
+  { initialValue: props.modelValue }
+)
 
 const src = computed(() => URL.createObjectURL(selectedImage.value))
 


### PR DESCRIPTION
- use the vee-validate field value to retrieve the `src` of the preview `img` tag => fixes the functionality of the component without passing a `modelValue` (which is the normal case for vee-validate)
- set `modelValue` as initial value of vee-validate field (to provide compatibility for `v-model`)