### PR TITLE
Modularize Box Components

### DIFF
--- a/src/atoms/boxes/BaseBox/BaseBox.stories.ts
+++ b/src/atoms/boxes/BaseBox/BaseBox.stories.ts
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/vue3'
+import BaseBox from './BaseBox.vue'
+
+export default {
+  component: BaseBox
+} as Meta<typeof BaseBox>
+type Story = StoryObj<typeof BaseBox>
+
+/**
+ * If only one error is given. It displays the error inside the box as string.
+ */
+export const Default: Story = {
+  render: () => ({
+    components: { BaseBox },
+    template: `
+      <BaseBox>Hello World!</BaseBox>`
+  })
+}

--- a/src/atoms/boxes/BaseBox/BaseBox.vue
+++ b/src/atoms/boxes/BaseBox/BaseBox.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="base-box">
+    <!-- @slot box content -->
+    <slot />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.base-box {
+  --_box-background-color: var(
+    --box-background-color,
+    var(--color-neutral-200)
+  );
+  --_box-border-radius: var(--box-border-radius, var(--border-radius-300));
+  --_box-padding: var(--box-padding, var(--space-sm));
+
+  padding: var(--space-sm);
+  border-radius: var(--_box-border-radius);
+  background-color: var(--_box-background-color);
+}
+</style>

--- a/src/atoms/boxes/ErrorBox/ErrorBox.spec.js
+++ b/src/atoms/boxes/ErrorBox/ErrorBox.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import ErrorBox from '@/atoms/boxes/ErrorBox/ErrorBox.vue'
 
-describe('PortalErrorBox', () => {
+describe('ErrorBox', () => {
   let wrapper
 
   beforeEach(() => {

--- a/src/atoms/boxes/ErrorBox/ErrorBox.vue
+++ b/src/atoms/boxes/ErrorBox/ErrorBox.vue
@@ -1,9 +1,10 @@
 <template>
-  <div
+  <BaseBox
     v-if="localErrors.length > 0"
     class="error-box"
     data-cy="portal-error-box"
   >
+    <IconWarning />
     <ul v-if="localErrors.length > 1">
       <li v-for="localError in localErrors" :key="localError.message">
         {{ localError.message }}
@@ -12,11 +13,13 @@
     <span v-else>
       {{ localErrors[0].message }}
     </span>
-  </div>
+  </BaseBox>
 </template>
 
 <script lang="ts" setup>
 import { computed } from 'vue'
+import IconWarning from '@/icons/IconWarning.vue'
+import BaseBox from '@/atoms/boxes/BaseBox/BaseBox.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -35,9 +38,16 @@ const localErrors = computed(() => {
 </script>
 <style lang="scss" scoped>
 .error-box {
+  --box-background-color: var(--color-danger-surface-300);
+
+  display: flex;
+  gap: var(--space-sm);
+  align-items: start;
   color: var(--color-danger-hover);
-  background-color: var(--color-danger-surface-300);
-  padding: var(--space-sm);
-  border-radius: var(--border-radius-300);
+
+  ul {
+    margin: 0;
+    padding-inline: 1rem;
+  }
 }
 </style>

--- a/src/atoms/boxes/InfoBox/InfoBox.spec.js
+++ b/src/atoms/boxes/InfoBox/InfoBox.spec.js
@@ -16,13 +16,13 @@ describe('InfoBox', () => {
         infoMessage: undefined
       })
       expect(wrapper.findComponent(IconInfoCircle).exists()).toBeFalsy()
-    }),
-      it(':infoMessage - show component when set', async () => {
-        const expectedInfoMessage = 'test info message'
-        await wrapper.setProps({
-          infoMessage: expectedInfoMessage
-        })
-        expect(wrapper.text()).toContain(expectedInfoMessage)
+    })
+    it(':infoMessage - show component when set', async () => {
+      const expectedInfoMessage = 'test info message'
+      await wrapper.setProps({
+        infoMessage: expectedInfoMessage
       })
+      expect(wrapper.text()).toContain(expectedInfoMessage)
+    })
   })
 })

--- a/src/atoms/boxes/InfoBox/InfoBox.spec.js
+++ b/src/atoms/boxes/InfoBox/InfoBox.spec.js
@@ -1,0 +1,28 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import InfoBox from '@/atoms/boxes/InfoBox/InfoBox.vue'
+import IconInfoCircle from '@/icons/IconInfoCircle.vue'
+
+describe('InfoBox', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(InfoBox)
+  })
+
+  describe(':props', () => {
+    it(':infoMessage - hides component when undefined', async () => {
+      await wrapper.setProps({
+        infoMessage: undefined
+      })
+      expect(wrapper.findComponent(IconInfoCircle).exists()).toBeFalsy()
+    }),
+      it(':infoMessage - show component when set', async () => {
+        const expectedInfoMessage = 'test info message'
+        await wrapper.setProps({
+          infoMessage: expectedInfoMessage
+        })
+        expect(wrapper.text()).toContain(expectedInfoMessage)
+      })
+  })
+})

--- a/src/atoms/boxes/InfoBox/InfoBox.stories.ts
+++ b/src/atoms/boxes/InfoBox/InfoBox.stories.ts
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/vue3'
+import InfoBox from './InfoBox.vue'
+
+export default {
+  component: InfoBox
+} as Meta<typeof InfoBox>
+type Story = StoryObj<typeof InfoBox>
+
+/**
+ * If only one error is given. It displays the error inside the box as string.
+ */
+export const Default: Story = {
+  args: {
+    infoMessage: 'This is an info message'
+  }
+}

--- a/src/atoms/boxes/InfoBox/InfoBox.vue
+++ b/src/atoms/boxes/InfoBox/InfoBox.vue
@@ -1,0 +1,28 @@
+<template>
+  <BaseBox class="info-box" v-if="infoMessage">
+    <IconInfoCircle />
+    {{ infoMessage }}
+  </BaseBox>
+</template>
+
+<script lang="ts" setup>
+import IconInfoCircle from '@/icons/IconInfoCircle.vue'
+import BaseBox from '@/atoms/boxes/BaseBox/BaseBox.vue'
+
+defineProps<{
+  /**
+   * the info message that shall be displayed
+   */
+  infoMessage?: string
+}>()
+</script>
+<style lang="scss" scoped>
+.info-box {
+  --box-background-color: var(--color-primary-100);
+  color: var(--color-neutral-600);
+
+  i {
+    margin-right: var(--space-sm);
+  }
+}
+</style>

--- a/src/atoms/boxes/MessageBox/MessageBox.spec.js
+++ b/src/atoms/boxes/MessageBox/MessageBox.spec.js
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import InfoBox from '@/atoms/boxes/InfoBox/InfoBox.vue'
+import MessageBox from '@/atoms/boxes/MessageBox/MessageBox.vue'
+import ErrorBox from '@/atoms/boxes/ErrorBox/ErrorBox.vue'
+
+describe('MessageBox', () => {
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = mount(MessageBox)
+  })
+
+  describe(':props', () => {
+    it(':infoMessage - is applied to InfoBox', async () => {
+      const expectedInfoMessage = 'test info message'
+      await wrapper.setProps({
+        infoMessage: expectedInfoMessage
+      })
+      expect(wrapper.findComponent(InfoBox).exists()).toBeTruthy()
+      expect(wrapper.findComponent(InfoBox).vm.infoMessage).toBe(
+        expectedInfoMessage
+      )
+      expect(wrapper.findComponent(ErrorBox).exists()).toBeFalsy()
+    })
+    it(':errorMessage - is applied to InfoBox', async () => {
+      const expectedErrorMessage = 'test info message'
+      await wrapper.setProps({
+        errorMessage: expectedErrorMessage
+      })
+      expect(wrapper.findComponent(InfoBox).exists()).toBeFalsy()
+      expect(wrapper.findComponent(ErrorBox).exists()).toBeTruthy()
+      expect(wrapper.findComponent(ErrorBox).vm.error).toStrictEqual(
+        new Error(expectedErrorMessage)
+      )
+    })
+  })
+})

--- a/src/atoms/boxes/MessageBox/MessageBox.vue
+++ b/src/atoms/boxes/MessageBox/MessageBox.vue
@@ -1,55 +1,25 @@
 <template>
-  <div
-    class="message-box"
-    v-if="errorMessage || infoMessage"
-    :class="classObject"
-  >
-    <span v-if="errorMessage"> <IconWarning /> {{ errorMessage }} </span>
-    <span v-if="infoMessage"> <IconInfoCircle />{{ infoMessage }} </span>
-    <slot v-else />
-  </div>
+  <ErrorBox v-if="errorMessage" :error="error" />
+  <InfoBox v-if="infoMessage" :info-message="infoMessage" />
 </template>
 
 <script lang="ts" setup>
+import ErrorBox from '@/atoms/boxes/ErrorBox/ErrorBox.vue'
+import InfoBox from '@/atoms/boxes/InfoBox/InfoBox.vue'
 import { computed } from 'vue'
-import IconInfoCircle from '@/icons/IconInfoCircle.vue'
-import IconWarning from '@/icons/IconWarning.vue'
 
-// TODO: only use this component for info message(s)?
 const props = defineProps<{
+  /**
+   * error message to display
+   */
   errorMessage?: string
+  /**
+   * info message to display
+   */
   infoMessage?: string
 }>()
 
-const classObject = computed(() => ({
-  error: !!props.errorMessage,
-  info: !!props.infoMessage
-}))
+const error = computed(() =>
+  props.errorMessage ? new Error(props.errorMessage) : undefined
+)
 </script>
-
-<style scoped lang="scss">
-.message-box {
-  padding: var(--space-sm);
-  border-radius: var(--border-radius-300);
-
-  span > i {
-    margin-right: var(--space-sm);
-  }
-
-  &.error {
-    background-color: var(--color-danger-surface-200);
-
-    span {
-      color: var(--color-danger);
-    }
-  }
-
-  &.info {
-    background-color: var(--color-info-surface);
-
-    span {
-      color: var(--color-neutral-600);
-    }
-  }
-}
-</style>

--- a/src/atoms/boxes/index.ts
+++ b/src/atoms/boxes/index.ts
@@ -1,0 +1,6 @@
+import BaseBox from '@/atoms/boxes/BaseBox/BaseBox.vue'
+import ErrorBox from '@/atoms/boxes/ErrorBox/ErrorBox.vue'
+import InfoBox from '@/atoms/boxes/InfoBox/InfoBox.vue'
+import MessageBox from '@/atoms/boxes/MessageBox/MessageBox.vue'
+
+export { BaseBox, ErrorBox, InfoBox, MessageBox }

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -57,3 +57,4 @@ export {
 }
 export * from './inputs'
 export * from './dashboard'
+export * from './boxes'

--- a/src/molecules/LoginForm/LoginForm.spec.ts
+++ b/src/molecules/LoginForm/LoginForm.spec.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { useForm } from 'vee-validate'
 import LoginForm from './LoginForm.vue'
-import BaseButton from '../../atoms/buttons/BaseButton/BaseButton.vue'
+import BaseButton from '@/atoms/buttons/BaseButton/BaseButton.vue'
+import ErrorBox from '@/atoms/boxes/ErrorBox/ErrorBox.vue'
 
 vi.mock('vee-validate', async () => {
   const actual = (await vi.importActual('vee-validate')) as object
@@ -38,7 +39,7 @@ describe('LoginForm', () => {
   describe(':props', () => {
     it(':errorMessage - form errorMessage is displayed', async () => {
       await wrapper.setProps({ errorMessage: 'error message' })
-      const errorMessage = wrapper.find('.error > span')
+      const errorMessage = wrapper.findComponent(ErrorBox)
       expect(errorMessage.isVisible()).toBe(true)
       expect(errorMessage.text()).toBe('error message')
     })


### PR DESCRIPTION
Introduces new and update existing box components:
- `BaseBox` generic box component that can be used to create new boxes
- `InfoBox` should be used to display a info message (background-color is a light primary)
- `ErrorBox` updated and uses now the `BaseBox`
- `MessageBox` updated and uses now the `ErrorBox` and `InfoBox`
  - **BREAKING_CHANGE**: removed the slot here. Use `BaseBox` instead