### PR TITLE
Fix: Change Entry Paths to Generated Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/library.umd.js",
+  "main": "./dist/library.cjs.js",
   "module": "./dist/library.es.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/library.es.js",
-      "require": "./dist/library.umd.js"
+      "require": "./dist/library.cjs.js"
     },
     "./dist/style.css": "./dist/style.css"
   },


### PR DESCRIPTION
The common js path seem to be wrong. The generated files are `library.cjs.js`