### PR TITLE
Fix: Base Button Different Heights at Different Variants

### DIFF
--- a/src/atoms/buttons/BaseButton/BaseButton.vue
+++ b/src/atoms/buttons/BaseButton/BaseButton.vue
@@ -75,7 +75,7 @@ export default defineComponent({
   max-width: 250px;
   padding: var(--space-sm) var(--space-md);
   border-radius: var(--border-radius-700);
-  line-height: 1rem;
+  line-height: 1;
   border: none;
   cursor: pointer;
 
@@ -120,10 +120,6 @@ export default defineComponent({
 
     .loading-icon {
       color: var(--color-button);
-      font-size: 1rem;
-      width: 1.4rem;
-      height: 1.4rem;
-      line-height: 0;
 
       &.animate {
         animation: scale 0.7s ease-in infinite;

--- a/src/atoms/buttons/BaseButton/BaseButton.vue
+++ b/src/atoms/buttons/BaseButton/BaseButton.vue
@@ -139,7 +139,7 @@ export default defineComponent({
     opacity: 1;
   }
   100% {
-    scale: 1.1;
+    scale: 1.2;
     opacity: 0.1;
   }
 }


### PR DESCRIPTION
- Fixes height bug (different default heights between busy state and the other ones)
- Increases loading icon max scale to impove the loading effect