### PR TITLE
Add option to disable default base layer in LeafletMap

### DIFF
--- a/src/atoms/map/LeafletMap/LeafletMap.spec.ts
+++ b/src/atoms/map/LeafletMap/LeafletMap.spec.ts
@@ -10,7 +10,8 @@ describe('LeafletMap', () => {
     initialCenter: LatLng = new LatLng(0.0, 0.0),
     initialZoom?: number,
     maxZoom?: number,
-    minZoom?: number
+    minZoom?: number,
+    osmBaseMap: boolean = true,
   ) => {
     return mount(LeafletMap, {
       attachTo: document.body,
@@ -19,7 +20,8 @@ describe('LeafletMap', () => {
         initialZoom,
         initialCenter,
         maxZoom,
-        minZoom
+        minZoom,
+        osmBaseMap
       }
     })
   }
@@ -66,6 +68,28 @@ describe('LeafletMap', () => {
 
       expect(wrapper.vm.map?.getMaxZoom()).toStrictEqual(expectedMaxZoom)
       expect(wrapper.vm.map?.getMinZoom()).toStrictEqual(expectedMinZoom)
+    })
+
+    it(':osmBaseMap - create default base layer when map is created', async () => {
+      wrapper.unmount()
+      const expectedBaseLayer = true
+      wrapper = mountComponent(undefined, 15, undefined, undefined, expectedBaseLayer)
+
+      let layerCount = 0
+      wrapper.vm.map?.eachLayer(() => layerCount++)
+
+      expect(layerCount).toStrictEqual(1)
+    })
+
+    it(':osmBaseMap - do not create default base layer when map is created', async () => {
+      wrapper.unmount()
+      const expectedBaseLayer = false
+      wrapper = mountComponent(undefined, 15, undefined, undefined, expectedBaseLayer)
+
+      let layerCount = 0
+      wrapper.vm.map?.eachLayer(() => layerCount++)
+
+      expect(layerCount).toStrictEqual(0)
     })
   })
 })

--- a/src/atoms/map/LeafletMap/LeafletMap.vue
+++ b/src/atoms/map/LeafletMap/LeafletMap.vue
@@ -18,6 +18,7 @@ const props = withDefaults(
     customControls?: Control[]
     contextMenu?: boolean
     hideControls?: boolean
+    osmBaseMap?: boolean
   }>(),
   {
     minZoom: 0,
@@ -25,7 +26,8 @@ const props = withDefaults(
     initialZoom: 14,
     customControls: () => [],
     contextMenu: false,
-    hideControls: false
+    hideControls: false,
+    osmBaseMap: true
   }
 )
 
@@ -44,7 +46,8 @@ const {
   props.minZoom,
   props.maxZoom,
   center,
-  props.customControls
+  props.customControls,
+  props.osmBaseMap,
 )
 defineExpose({ map }) // for testing
 

--- a/src/composables/useLeafletMap.ts
+++ b/src/composables/useLeafletMap.ts
@@ -8,7 +8,8 @@ export function useLeafletMap(
   minZoom: number,
   maxZoom: number,
   center: Ref<LatLng>,
-  controls: Control[]
+  controls: Control[],
+  osmBaseMap: boolean = true
 ) {
   const map = shallowRef<Map | undefined>() as Ref<Map | undefined>
   const initMap = (
@@ -27,16 +28,19 @@ export function useLeafletMap(
     } as unknown as MapOptions) as Map
     map.value.setView(center, zoom)
 
-    const baseLayer = new TileLayer(
-      'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-      {
-        maxZoom,
-        minZoom,
-        attribution:
-          '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-      }
-    )
-    map.value.addLayer(baseLayer)
+    if (osmBaseMap) {
+      const baseLayer = new TileLayer(
+          'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+          {
+              maxZoom,
+              minZoom,
+              attribution:
+                  '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          }
+      )
+      map.value.addLayer(baseLayer)
+    }
+
     addCustomControls(map.value)
   }
 


### PR DESCRIPTION
Fixes #106 by introducing an optional parameter to control whether the default OSM base layer should be created. Default behavior remains the same (OSM base layer is added).