### PR TITLE
Synchronize internal state and state variable of Leaflet ButtonControl

### DIFF
--- a/src/composables/useLeafletButtonControl.ts
+++ b/src/composables/useLeafletButtonControl.ts
@@ -1,9 +1,17 @@
-import { ref } from 'vue'
-import { ButtonControl } from '@/models/leafletButtonControl'
+import {Ref, ref} from 'vue'
+import {ButtonControl, StateChangeType} from '@/models/leafletButtonControl'
 
-export function useLeafletButtonControl(iconKey: string, tooltipTitle: string) {
+export function useLeafletButtonControl(
+  iconKey: string,
+  tooltipTitle: string,
+  stateChangeHook?: (
+    changedState: Ref<boolean>,
+    changeType: StateChangeType
+  ) => void
+) {
+
   const isActive = ref<boolean>(false)
-  const buttonControl = new ButtonControl(isActive, iconKey, tooltipTitle)
+  const buttonControl = new ButtonControl(isActive, iconKey, tooltipTitle, stateChangeHook)
 
   return { buttonControl, isActive }
 }

--- a/src/composables/useLeafletButtonControl.ts
+++ b/src/composables/useLeafletButtonControl.ts
@@ -1,17 +1,9 @@
-import {Ref, ref} from 'vue'
-import {ButtonControl, StateChangeType} from '@/models/leafletButtonControl'
+import {ref} from 'vue'
+import {ButtonControl} from '@/models/leafletButtonControl'
 
-export function useLeafletButtonControl(
-  iconKey: string,
-  tooltipTitle: string,
-  stateChangeHook?: (
-    changedState: Ref<boolean>,
-    changeType: StateChangeType
-  ) => void
-) {
-
+export function useLeafletButtonControl(iconKey: string, tooltipTitle: string) {
   const isActive = ref<boolean>(false)
-  const buttonControl = new ButtonControl(isActive, iconKey, tooltipTitle, stateChangeHook)
+  const buttonControl = new ButtonControl(isActive, iconKey, tooltipTitle)
 
   return { buttonControl, isActive }
 }

--- a/src/composables/useLeafletButtonControl.ts
+++ b/src/composables/useLeafletButtonControl.ts
@@ -1,5 +1,5 @@
-import {ref} from 'vue'
-import {ButtonControl} from '@/models/leafletButtonControl'
+import { ref } from 'vue'
+import { ButtonControl } from '@/models/leafletButtonControl'
 
 export function useLeafletButtonControl(iconKey: string, tooltipTitle: string) {
   const isActive = ref<boolean>(false)

--- a/src/models/leafletButtonControl.ts
+++ b/src/models/leafletButtonControl.ts
@@ -2,27 +2,17 @@ import { Control, DomEvent, DomUtil, Map } from 'leaflet'
 import type { Ref } from 'vue'
 import {watch} from "vue";
 
-export enum StateChangeType {
-    ACTIVATION,
-    DEACTIVATION,
-}
-
 export class ButtonControl extends Control {
   readonly state: Ref<boolean>
   readonly activeClass = 'active'
   readonly iconKey: string
   readonly tooltipTitle: string
-  readonly stateChangeHook?: (
-      changedState: Ref<boolean>,
-      changeType: StateChangeType
-  ) => void
 
-  constructor(state: Ref<boolean>, iconKey: string, tooltipTitle: string, stateChangeHook?: (changedState: Ref<boolean>, changeType: StateChangeType) => void) {
+  constructor(state: Ref<boolean>, iconKey: string, tooltipTitle: string) {
     super()
     this.state = state
     this.iconKey = iconKey
     this.tooltipTitle = tooltipTitle
-    this.stateChangeHook = stateChangeHook
   }
 
   onAdd(_map: Map) {
@@ -36,19 +26,12 @@ export class ButtonControl extends Control {
 
     container.title = this.tooltipTitle
 
-    watch(this.state, () => {
-      let changeType: StateChangeType
-
-      if (this.state.value) {
+    // keep this.state and the button DOM element's "active" HTML-class in sync
+    watch(this.state, (newState: boolean): void => {
+      if (newState) {
         button.classList.add(this.activeClass)
-        changeType = StateChangeType.ACTIVATION
       } else {
         button.classList.remove(this.activeClass)
-        changeType = StateChangeType.DEACTIVATION
-      }
-
-      if (this.stateChangeHook) {
-        this.stateChangeHook(this.state, changeType)
       }
     })
 

--- a/src/models/leafletButtonControl.ts
+++ b/src/models/leafletButtonControl.ts
@@ -1,17 +1,28 @@
 import { Control, DomEvent, DomUtil, Map } from 'leaflet'
 import type { Ref } from 'vue'
+import {watch} from "vue";
+
+export enum StateChangeType {
+    ACTIVATION,
+    DEACTIVATION,
+}
 
 export class ButtonControl extends Control {
   readonly state: Ref<boolean>
   readonly activeClass = 'active'
   readonly iconKey: string
   readonly tooltipTitle: string
+  readonly stateChangeHook?: (
+      changedState: Ref<boolean>,
+      changeType: StateChangeType
+  ) => void
 
-  constructor(state: Ref<boolean>, iconKey: string, tooltipTitle: string) {
+  constructor(state: Ref<boolean>, iconKey: string, tooltipTitle: string, stateChangeHook?: (changedState: Ref<boolean>, changeType: StateChangeType) => void) {
     super()
     this.state = state
     this.iconKey = iconKey
     this.tooltipTitle = tooltipTitle
+    this.stateChangeHook = stateChangeHook
   }
 
   onAdd(_map: Map) {
@@ -20,10 +31,26 @@ export class ButtonControl extends Control {
     button.innerHTML = `<i class='bi ${this.iconKey}'></i>`
     DomEvent.disableClickPropagation(button)
     DomEvent.on(button, 'click', () => {
-      this.state.value = button.classList.toggle(this.activeClass)
+        this.state.value = !this.state.value
     })
 
     container.title = this.tooltipTitle
+
+    watch(this.state, () => {
+      let changeType: StateChangeType
+
+      if (this.state.value) {
+        button.classList.add(this.activeClass)
+        changeType = StateChangeType.ACTIVATION
+      } else {
+        button.classList.remove(this.activeClass)
+        changeType = StateChangeType.DEACTIVATION
+      }
+
+      if (this.stateChangeHook) {
+        this.stateChangeHook(this.state, changeType)
+      }
+    })
 
     return container
   }

--- a/src/models/leafletButtonControl.ts
+++ b/src/models/leafletButtonControl.ts
@@ -1,6 +1,6 @@
 import { Control, DomEvent, DomUtil, Map } from 'leaflet'
 import type { Ref } from 'vue'
-import {watch} from "vue";
+import { watch } from "vue";
 
 export class ButtonControl extends Control {
   readonly state: Ref<boolean>
@@ -21,7 +21,7 @@ export class ButtonControl extends Control {
     button.innerHTML = `<i class='bi ${this.iconKey}'></i>`
     DomEvent.disableClickPropagation(button)
     DomEvent.on(button, 'click', () => {
-        this.state.value = !this.state.value
+      this.state.value = !this.state.value
     })
 
     container.title = this.tooltipTitle


### PR DESCRIPTION
Fixes #107 by ensuring synchronization of the control's `active` HTML-class and the `state` attribute. Clicking the control now toggles the `state` boolean and the `active` HTML-class is updated via a Vue watcher every time `state` changes. This ensures synchronization of the boolean and the HTML-class.