### PR TITLE
Fix: Configurable Dashboard 4

### DIFF
--- a/packages/core/src/components/inputs/SelectInput/SelectInput.vue
+++ b/packages/core/src/components/inputs/SelectInput/SelectInput.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="floating-input-group">
     <multiselect
-      :id="id"
+      :id="props.id"
       v-model="selectedOption"
-      :options="options"
+      :options="props.options"
       :placeholder="placeholderText"
       track-by="key"
       label="label"
@@ -14,7 +14,7 @@
       :allow-empty="false"
       :show-labels="false"
       v-bind="$attrs"
-      @select="emitKey"
+      @select="updateModelValue"
     >
       <template v-for="(_, name) in $slots" #[name]>
         <slot :name="name" />
@@ -30,17 +30,13 @@
 </template>
 <script setup lang="ts" generic="LabelType">
 import Multiselect from 'vue-multiselect'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { SelectOption } from '@core/components/inputs/BaseSelect/selectOption'
 
 const PLACEHOLDER_SUFFIX = 'wählen'
 
 const props = withDefaults(
   defineProps<{
-    /**
-     * The currently selected value as a `string`, initially `undefined`.
-     */
-    modelValue?: string
     /**
      * The options that should be available for selection. Contain a `value` (key to identify the option)
      * and a text to be displayed.
@@ -72,15 +68,16 @@ const props = withDefaults(
   }
 )
 
-const emit = defineEmits<{
-  (e: 'update:modelValue', value: string | number | null): void
-}>()
+/**
+ * The currently selected value as a `string`, initially `undefined`.
+ */
+const modelValue = defineModel<string | undefined | null | number>()
 
 const selectedOption = ref<SelectOption<LabelType>>()
 
 onMounted(() => {
-  const { modelValue, options, defaultOption } = props
-  if (modelValue !== undefined) {
+  const { options, defaultOption } = props
+  if (modelValue.value !== undefined && modelValue.value !== null) {
     const optionsMap = options.reduce(
       (
         accumulator: { [key: string]: SelectOption<LabelType> },
@@ -91,14 +88,37 @@ onMounted(() => {
       },
       {}
     )
-    selectedOption.value = optionsMap[modelValue]
+    selectedOption.value = optionsMap[modelValue.value]
   } else {
     selectedOption.value = defaultOption
   }
   if (selectedOption.value !== undefined) {
-    emitKey(selectedOption.value)
+    updateModelValue(selectedOption.value)
   }
 })
+
+watch(
+  () => modelValue.value,
+  (newValue) => {
+    if (
+      newValue !== undefined &&
+      newValue !== null &&
+      props.options.length > 0
+    ) {
+      const optionsMap = props.options.reduce(
+        (
+          accumulator: { [key: string]: SelectOption<LabelType> },
+          selectOption: SelectOption<LabelType>
+        ) => {
+          accumulator[selectOption.key || ''] = selectOption
+          return accumulator
+        },
+        {}
+      )
+      selectedOption.value = optionsMap[newValue]
+    }
+  }
+)
 
 const placeholderText = computed(() => {
   return props.placeholder || props.label + ' ' + PLACEHOLDER_SUFFIX
@@ -108,8 +128,8 @@ const errorMessage = computed(() =>
   props.error instanceof Error ? props.error.message : props.error
 )
 
-const emitKey = (selectedOption: SelectOption<LabelType>) => {
-  emit('update:modelValue', selectedOption.key)
+const updateModelValue = (selectedOption: SelectOption<LabelType>) => {
+  modelValue.value = selectedOption.key
 }
 </script>
 <style>

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts" setup>
-import { nextTick, ref } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { WidgetComponentWrapper } from '@/models/widgetComponentWrapper'
 import { WidgetConfiguration } from '@/models/widgetConfiguration'
 import { GridWidget } from '@/models/gridWidget'
@@ -58,6 +58,9 @@ const dashboardConfig = defineModel<WidgetConfiguration[]>('dashboardConfig', {
   required: true
 })
 
+/**
+ * Currently set dashboardConfig
+ */
 const currentConfig = ref(dashboardConfig.value)
 const editMode = ref<boolean>(false)
 const showModal = ref(false)
@@ -94,6 +97,12 @@ const onAddWidget = async (widgetKey: string) => {
       ?.scrollIntoView({ behavior: 'smooth' })
   }, 250)
 }
+
+watch(editMode, (isEditMode) => {
+  if (isEditMode) {
+    currentConfig.value = dashboardConfig.value
+  }
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
- Update SelectInput to the name of the newly saved dashboard configuration on `onSave`
- Save the dashboard configuration to `currentConfiguration` on start of `editMode`, so that cancel `editMode` returns it to that last form.