### PR TITLE
✨ Add Currency Input

### DIFF
--- a/packages/core/src/components/inputs/BaseInputWrapper/BaseInputWrapper.vue
+++ b/packages/core/src/components/inputs/BaseInputWrapper/BaseInputWrapper.vue
@@ -100,31 +100,31 @@
     font-size: var(--_label-size);
   }
 
-  :deep(input.failed ~ label) {
+  :deep(input.invalid ~ label) {
     color: var(--_input-error-color);
   }
 
-  :deep(input.failed ~ .error-icon) {
+  :deep(input.invalid ~ .error-icon) {
     display: inline-block;
   }
 
-  :deep(input.failed ~ .postfix-icon) {
+  :deep(input.invalid ~ .postfix-icon) {
     display: none;
   }
 
-  :deep(input.failed:hover ~ label) {
+  :deep(input.invalid:hover ~ label) {
     color: var(--_input-error-color-hover);
   }
 
-  :deep(input.failed:not(:focus)) {
+  :deep(input.invalid:not(:focus)) {
     outline: 2px solid var(--_input-error-color);
   }
 
-  :deep(input.failed:not(:focus):hover) {
+  :deep(input.invalid:not(:focus):hover) {
     outline: 2px solid var(--_input-error-color-hover);
   }
 
-  :deep(input.failed:not(:focus):hover ~ .error-icon),
+  :deep(input.invalid:not(:focus):hover ~ .error-icon),
   :deep(.error-icon):hover {
     color: var(--_input-error-color-hover);
   }

--- a/packages/core/src/components/inputs/BaseInputWrapper/BaseInputWrapper.vue
+++ b/packages/core/src/components/inputs/BaseInputWrapper/BaseInputWrapper.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="base-input-wrapper">
     <slot />
+    <div class="postfix-icon"><slot name="postfix-icon" /></div>
     <IconError class="error-icon" />
   </div>
 </template>
@@ -20,7 +21,8 @@
 
   & > :deep(input),
   & > :deep(label),
-  & > .error-icon {
+  & > .error-icon,
+  & > .postfix-icon {
     grid-row: 1 / 2;
     grid-column: 1 / 2;
     font-size: var(--_input-size);
@@ -35,11 +37,15 @@
     );
   }
 
-  .error-icon {
-    display: none;
+  .error-icon,
+  .postfix-icon {
     font-size: var(--_error-icon-size);
-    color: var(--color-danger);
     place-self: center end;
+  }
+
+  .error-icon {
+    color: var(--color-danger);
+    display: none;
   }
 
   & > :deep(input) {
@@ -100,6 +106,10 @@
 
   :deep(input.failed ~ .error-icon) {
     display: inline-block;
+  }
+
+  :deep(input.failed ~ .postfix-icon) {
+    display: none;
   }
 
   :deep(input.failed:hover ~ label) {

--- a/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.spec.ts
+++ b/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import type { defineComponent } from 'vue'
+import { ErrorMessage, Field } from 'vee-validate'
+import CurrencyInput from './CurrencyInput.vue'
+
+describe('CurrencyInput.vue', () => {
+  let wrapper: ReturnType<typeof defineComponent>
+
+  beforeEach(() => {
+    wrapper = mount(CurrencyInput, {
+      props: {
+        name: 'name',
+        label: 'label'
+      }
+    })
+  })
+  describe(':props', () => {
+    it(':name - is applied to Field', async () => {
+      const expectedName = 'expectedFieldName'
+      await wrapper.setProps({ name: expectedName })
+      expect(wrapper.findComponent(Field).vm.name).toBe(expectedName)
+      expect(wrapper.findComponent(Field).attributes('id')).toBe(expectedName)
+    })
+    it(':name - is applied to ErrorMessage', async () => {
+      const expectedName = 'expectedFieldName'
+      await wrapper.setProps({ name: expectedName })
+      expect(wrapper.findComponent(ErrorMessage).vm.name).toBe(expectedName)
+    })
+    it(':label - is rendered as label', async () => {
+      const expectedLabel = 'Expected Label'
+      await wrapper.setProps({ label: expectedLabel })
+      expect(wrapper.find('label').text()).toBe(expectedLabel)
+    })
+    it(':type - default type is text', async () => {
+      expect(wrapper.findComponent(Field).attributes('type')).toBe('text')
+    })
+    it(':type - is applied to Field', async () => {
+      const expectedType = 'email'
+      await wrapper.setProps({ type: expectedType })
+      expect(wrapper.findComponent(Field).attributes('type')).toBe(expectedType)
+    })
+  })
+})

--- a/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.spec.ts
+++ b/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import type { defineComponent } from 'vue'
-import { ErrorMessage, Field } from 'vee-validate'
+import { ErrorMessage } from 'vee-validate'
 import CurrencyInput from './CurrencyInput.vue'
 
 describe('CurrencyInput.vue', () => {
@@ -10,35 +10,138 @@ describe('CurrencyInput.vue', () => {
   beforeEach(() => {
     wrapper = mount(CurrencyInput, {
       props: {
-        name: 'name',
-        label: 'label'
+        name: 'name'
       }
     })
   })
   describe(':props', () => {
-    it(':name - is applied to Field', async () => {
+    it(':name - is applied to input and label', async () => {
       const expectedName = 'expectedFieldName'
       await wrapper.setProps({ name: expectedName })
-      expect(wrapper.findComponent(Field).vm.name).toBe(expectedName)
-      expect(wrapper.findComponent(Field).attributes('id')).toBe(expectedName)
+      expect(wrapper.find('input').attributes('id')).toBe(expectedName)
+      expect(wrapper.find('input').attributes('name')).toBe(expectedName)
+      expect(wrapper.find('label').attributes('for')).toBe(expectedName)
     })
     it(':name - is applied to ErrorMessage', async () => {
       const expectedName = 'expectedFieldName'
       await wrapper.setProps({ name: expectedName })
       expect(wrapper.findComponent(ErrorMessage).vm.name).toBe(expectedName)
     })
+    it(':label - "Betrag" is used if undefined', async () => {
+      await wrapper.setProps({ label: undefined })
+      expect(wrapper.find('label').text()).toBe('Betrag')
+    })
     it(':label - is rendered as label', async () => {
       const expectedLabel = 'Expected Label'
       await wrapper.setProps({ label: expectedLabel })
       expect(wrapper.find('label').text()).toBe(expectedLabel)
     })
-    it(':type - default type is text', async () => {
-      expect(wrapper.findComponent(Field).attributes('type')).toBe('text')
+    it(':cents - are applied to input', async () => {
+      await wrapper.setProps({ cents: 1234 })
+      await flushPromises()
+      expect(wrapper.find('input').element.value).toBe('12,34')
     })
-    it(':type - is applied to Field', async () => {
-      const expectedType = 'email'
-      await wrapper.setProps({ type: expectedType })
-      expect(wrapper.findComponent(Field).attributes('type')).toBe(expectedType)
+  })
+
+  describe('@events', () => {
+    it('@update:cents - does not emit if user input 0 at first position', async () => {
+      const input = wrapper.find('input')
+      await input.trigger('input', { data: '0' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).not.toHaveProperty('update:cents')
+      expect(wrapper.find('input').element.value).toBe('00,00')
+    })
+    it('@update:cents - does not emit if user inputs invalid characters', async () => {
+      await wrapper.setProps({ cents: 123 })
+      const input = wrapper.find('input')
+      await input.trigger('input', { data: 'a' })
+      await input.trigger('input', { data: 'z' })
+      await input.trigger('input', { data: '%' })
+      await input.trigger('input', { data: '.' })
+      await input.trigger('input', { data: ',' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).not.toHaveProperty('update:cents')
+      expect(wrapper.find('input').element.value).toBe('01,23')
+    })
+    it('@update:cents - emit 123 if user types 1,23 €', async () => {
+      const input = wrapper.find('input')
+      await input.trigger('input', { data: '1' })
+      await input.trigger('input', { data: '2' })
+      await input.trigger('input', { data: '3' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('update:cents')
+      expect(wrapper.emitted('update:cents')).toHaveLength(3)
+      expect(wrapper.emitted('update:cents').at(0)).toStrictEqual([1])
+      expect(wrapper.emitted('update:cents').at(1)).toStrictEqual([12])
+      expect(wrapper.emitted('update:cents').at(2)).toStrictEqual([123])
+      expect(wrapper.find('input').element.value).toBe('01,23')
+    })
+    it('@update:cents - emit 120 if user input 0 at last position of 00,12 €', async () => {
+      const input = wrapper.find('input')
+      await input.trigger('input', { data: '1' })
+      await input.trigger('input', { data: '2' })
+      await input.trigger('input', { data: '0' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('update:cents')
+      expect(wrapper.emitted('update:cents')).toHaveLength(3)
+      expect(wrapper.emitted('update:cents').at(0)).toStrictEqual([1])
+      expect(wrapper.emitted('update:cents').at(1)).toStrictEqual([12])
+      expect(wrapper.emitted('update:cents').at(2)).toStrictEqual([120])
+      expect(wrapper.find('input').element.value).toBe('01,20')
+    })
+    it('@update:cents - emit 12 if user deletes the last position', async () => {
+      await wrapper.setProps({ cents: 123 })
+      const input = wrapper.find('input')
+      await input.trigger('keydown', { key: 'Backspace' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('update:cents')
+      expect(wrapper.emitted('update:cents')).toHaveLength(1)
+      expect(wrapper.emitted('update:cents').at(0)).toStrictEqual([12])
+      expect(wrapper.find('input').element.value).toBe('00,12')
+    })
+    it('@update:cents - emit 0 if last position deleted', async () => {
+      await wrapper.setProps({ cents: 1 })
+      const input = wrapper.find('input')
+      await input.trigger('keydown', { key: 'Backspace' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('update:cents')
+      expect(wrapper.emitted('update:cents')).toHaveLength(1)
+      expect(wrapper.emitted('update:cents').at(0)).toStrictEqual([0])
+      expect(wrapper.find('input').element.value).toBe('00,00')
+    })
+    // 1.13 is critical float number. If we calculate the cent wrong it will fail
+    // 1.13 * 100 is 112.99999999999999
+    // !This is not a guarantee that the conversion is correct!
+    it('@update:cents - emits 113 on user input 1,13 €', async () => {
+      const input = wrapper.find('input')
+      await input.trigger('input', { data: '1' })
+      await input.trigger('input', { data: '1' })
+      await input.trigger('input', { data: '3' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('update:cents')
+      expect(wrapper.emitted('update:cents').at(-1)).toStrictEqual([113])
+      expect(wrapper.find('input').element.value).toBe('01,13')
+    })
+    // 1.13 is critical float number. If we calculate the cent wrong it will fail
+    // 1.13 * 100 is 112.99999999999999
+    // !This is not a guarantee that the conversion is correct!
+    it('@update:cents - emits 112 on user input 1,12 €', async () => {
+      const input = wrapper.find('input')
+      await input.trigger('input', { data: '1' })
+      await input.trigger('input', { data: '1' })
+      await input.trigger('input', { data: '2' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('update:cents')
+      expect(wrapper.emitted('update:cents').at(-1)).toStrictEqual([112])
+      expect(wrapper.find('input').element.value).toBe('01,12')
     })
   })
 })

--- a/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.stories.ts
+++ b/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.stories.ts
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from '@storybook/vue3'
+import { Form } from 'vee-validate'
+import CurrencyInput from './CurrencyInput.vue'
+
+export default {
+  component: CurrencyInput
+} as Meta<typeof CurrencyInput>
+type Story = StoryObj<typeof CurrencyInput>
+
+export const TextInput: Story = {
+  render: (args: unknown) => ({
+    components: { CurrencyInput, Form },
+    setup() {
+      return { args }
+    },
+    template: `
+      <Form :initialValues='{input1: "Text Input"}'>
+        <CurrencyInput v-bind='args' />
+      </Form>`
+  }),
+  args: {
+    name: 'input1',
+    label: 'Text Input',
+    type: 'text'
+  }
+}
+
+export const Empty: Story = {
+  args: {
+    name: 'test-empty'
+  }
+}
+
+export const WithError: Story = {
+  render: (args: unknown) => ({
+    components: { CurrencyInput, Form },
+    setup() {
+      return { args }
+    },
+    template: `
+      <Form :initialValues='{"input-with-error": "Some wrong text"}'
+            :initialTouched='{"input-with-error": true}'
+            :validateOnMount='true'
+            :initialErrors='{"input-with-error": "This is an error"}'
+      >
+        <CurrencyInput v-bind='args' />
+      </Form>`
+  }),
+  args: {
+    name: 'input-with-error'
+  }
+}

--- a/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.stories.ts
+++ b/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.stories.ts
@@ -2,32 +2,36 @@ import { Meta, StoryObj } from '@storybook/vue3'
 import { Form } from 'vee-validate'
 import CurrencyInput from './CurrencyInput.vue'
 
+/**
+ * The CurrencyInput component is used to input a cent amount. The inserted value is formatted as euros.
+ *
+ * The design files can be found in [figma](https://www.figma.com/file/t7Sf0lcqLOFsWf9IfczzDf/Bamberg-Gutschein?type=design&node-id=2215%3A9872&mode=design&t=HMv5F0wNEzgDKZeY-1)
+ */
+
 export default {
   component: CurrencyInput
 } as Meta<typeof CurrencyInput>
 type Story = StoryObj<typeof CurrencyInput>
 
-export const TextInput: Story = {
+export const Empty: Story = {
+  args: {
+    name: 'test-empty'
+  }
+}
+
+export const Filled: Story = {
   render: (args: unknown) => ({
     components: { CurrencyInput, Form },
     setup() {
       return { args }
     },
     template: `
-      <Form :initialValues='{input1: "Text Input"}'>
+      <Form :initialValues='{ input1: 234 }'>
         <CurrencyInput v-bind='args' />
       </Form>`
   }),
   args: {
-    name: 'input1',
-    label: 'Text Input',
-    type: 'text'
-  }
-}
-
-export const Empty: Story = {
-  args: {
-    name: 'test-empty'
+    name: 'input1'
   }
 }
 
@@ -38,7 +42,7 @@ export const WithError: Story = {
       return { args }
     },
     template: `
-      <Form :initialValues='{"input-with-error": "Some wrong text"}'
+      <Form :initialValues='{"input-with-error": -100}'
             :initialTouched='{"input-with-error": true}'
             :validateOnMount='true'
             :initialErrors='{"input-with-error": "This is an error"}'

--- a/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.vue
+++ b/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.vue
@@ -1,15 +1,19 @@
 <template>
   <BaseInputWrapper>
     <input
-      ref="currencyInputField"
       :id="name"
+      :class="{
+        dirty: meta.dirty,
+        valid: meta.touched && meta.valid,
+        invalid: meta.touched && !meta.valid
+      }"
       :name="name"
       type="tel"
       :value="displayedCurrencyValue"
       placeholder="hidden"
       v-bind="$attrs"
-      @input="handleInput"
-      @keydown.delete="handleDelete"
+      @input="onRawInput"
+      @keydown.delete="onDelete"
       @blur="handleBlur"
     />
     <label :for="name">{{ label }}</label>
@@ -18,16 +22,12 @@
       <i class="bi bi-currency-euro"></i>
     </template>
   </BaseInputWrapper>
-  {{ value }}
 </template>
 <script setup lang="ts">
 import { ErrorMessage, useField } from 'vee-validate'
 import BaseInputWrapper from '@core/components/inputs/BaseInputWrapper/BaseInputWrapper.vue'
-import { ref } from 'vue'
-
-/**
- * See https://www.figma.com/file/t7Sf0lcqLOFsWf9IfczzDf/Bamberg-Gutschein?type=design&node-id=2215%3A9872&mode=design&t=HMv5F0wNEzgDKZeY-1
- */
+import { ref, watch } from 'vue'
+import { useCurrencyFormat } from '@core/components/inputs/CurrencyInput/useCurrencyFormat'
 
 const props = withDefaults(
   defineProps<{
@@ -39,18 +39,28 @@ const props = withDefaults(
      * The text to be displayed within a floating label of this field.
      */
     label?: string
+    /**
+     * The value of the input field. Mainly used for backwards compatibility to our old forms.
+     * Please use the vee validate form to fill this field instead.
+     */
+    cents?: number
   }>(),
   {
     label: 'Betrag'
   }
 )
 
-const INITIAL_VALUE_SIZE = 4
+/**
+ * The internal string representation of the number.
+ * Used to easily add and remove characters and to format the displayed value and the convert to the number value.
+ */
 const internalValue = ref<string>('')
-const currencyInputField = ref<HTMLInputElement | null>(null)
 const displayedCurrencyValue = ref<string>('00,00')
 
-const handleInput = (event: InputEvent) => {
+const onRawInput = (event: Event) => {
+  onInput(event as InputEvent)
+}
+const onInput = (event: InputEvent) => {
   if (event.data == null || event.data.match(/[0-9]/) == null) {
     ;(event.target as HTMLInputElement).value = displayedCurrencyValue.value
     return
@@ -59,42 +69,56 @@ const handleInput = (event: InputEvent) => {
     ;(event.target as HTMLInputElement).value = displayedCurrencyValue.value
     return
   }
-  handleAdd(event.data)
+  onAdd(event.data)
 }
 
-const fillWithZeros = (value: string) => {
-  const missingZeros = INITIAL_VALUE_SIZE - value.length
-  if (missingZeros <= 0) {
-    return value
-  }
-  return '0'.repeat(missingZeros) + value
-}
-
-const formatCurrency = (value: string) => {
-  const filledValue = fillWithZeros(value)
-  return filledValue.slice(0, -2) + ',' + filledValue.slice(-2)
-}
-
-const handleAdd = (inputValue: string) => {
+/**
+ * Adds the given input value to the internal value.
+ * Sets the displayed currency value to the formatted internal value.
+ * Sets the value of the field as a number.
+ *
+ * @param inputValue The value to be added to the internal value.
+ */
+const onAdd = (inputValue: string) => {
   internalValue.value = internalValue.value + inputValue
-  displayedCurrencyValue.value = formatCurrency(internalValue.value)
-  setValue(parseInt(internalValue.value))
+  value.value = parseInt(internalValue.value)
 }
 
-const handleDelete = () => {
+/**
+ * Deletes the last character of the internal value.
+ * If the internal value is empty, nothing happens.
+ * Sets the displayed currency value to the formatted internal value.
+ * Sets the value of the field as a number.
+ */
+const onDelete = () => {
   if (internalValue.value.length === 0) {
     return
   }
   internalValue.value = internalValue.value.slice(0, -1)
-  displayedCurrencyValue.value = formatCurrency(internalValue.value)
-  setValue(parseInt(internalValue.value || '0'))
+  value.value = parseInt(internalValue.value || '0')
 }
-const { value, setValue, handleBlur } = useField<number>(
-  props.name,
-  (value) => value < 0,
+
+const { value, handleBlur, meta } = useField<number>(
+  () => props.name,
+  (value) => value >= 0 || 'Der Betrag muss größer oder gleich 0 sein.',
   {
-    initialValue: 0
+    syncVModel: 'cents'
   }
+)
+
+watch(
+  value,
+  (newValue: number) => {
+    if (newValue == null) {
+      return
+    }
+    internalValue.value = newValue.toString()
+    const { toEuroStringFromCentString } = useCurrencyFormat()
+    displayedCurrencyValue.value = toEuroStringFromCentString(
+      internalValue.value
+    )
+  },
+  { immediate: true }
 )
 </script>
 <style scoped lang="scss"></style>

--- a/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.vue
+++ b/packages/core/src/components/inputs/CurrencyInput/CurrencyInput.vue
@@ -1,0 +1,100 @@
+<template>
+  <BaseInputWrapper>
+    <input
+      ref="currencyInputField"
+      :id="name"
+      :name="name"
+      type="tel"
+      :value="displayedCurrencyValue"
+      placeholder="hidden"
+      v-bind="$attrs"
+      @input="handleInput"
+      @keydown.delete="handleDelete"
+      @blur="handleBlur"
+    />
+    <label :for="name">{{ label }}</label>
+    <ErrorMessage class="error" :name="name" />
+    <template #postfix-icon>
+      <i class="bi bi-currency-euro"></i>
+    </template>
+  </BaseInputWrapper>
+  {{ value }}
+</template>
+<script setup lang="ts">
+import { ErrorMessage, useField } from 'vee-validate'
+import BaseInputWrapper from '@core/components/inputs/BaseInputWrapper/BaseInputWrapper.vue'
+import { ref } from 'vue'
+
+/**
+ * See https://www.figma.com/file/t7Sf0lcqLOFsWf9IfczzDf/Bamberg-Gutschein?type=design&node-id=2215%3A9872&mode=design&t=HMv5F0wNEzgDKZeY-1
+ */
+
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Used to identify this field in a form (VeeValidate Form).
+     */
+    name: string
+    /**
+     * The text to be displayed within a floating label of this field.
+     */
+    label?: string
+  }>(),
+  {
+    label: 'Betrag'
+  }
+)
+
+const INITIAL_VALUE_SIZE = 4
+const internalValue = ref<string>('')
+const currencyInputField = ref<HTMLInputElement | null>(null)
+const displayedCurrencyValue = ref<string>('00,00')
+
+const handleInput = (event: InputEvent) => {
+  if (event.data == null || event.data.match(/[0-9]/) == null) {
+    ;(event.target as HTMLInputElement).value = displayedCurrencyValue.value
+    return
+  }
+  if (internalValue.value.length === 0 && event.data === '0') {
+    ;(event.target as HTMLInputElement).value = displayedCurrencyValue.value
+    return
+  }
+  handleAdd(event.data)
+}
+
+const fillWithZeros = (value: string) => {
+  const missingZeros = INITIAL_VALUE_SIZE - value.length
+  if (missingZeros <= 0) {
+    return value
+  }
+  return '0'.repeat(missingZeros) + value
+}
+
+const formatCurrency = (value: string) => {
+  const filledValue = fillWithZeros(value)
+  return filledValue.slice(0, -2) + ',' + filledValue.slice(-2)
+}
+
+const handleAdd = (inputValue: string) => {
+  internalValue.value = internalValue.value + inputValue
+  displayedCurrencyValue.value = formatCurrency(internalValue.value)
+  setValue(parseInt(internalValue.value))
+}
+
+const handleDelete = () => {
+  if (internalValue.value.length === 0) {
+    return
+  }
+  internalValue.value = internalValue.value.slice(0, -1)
+  displayedCurrencyValue.value = formatCurrency(internalValue.value)
+  setValue(parseInt(internalValue.value || '0'))
+}
+const { value, setValue, handleBlur } = useField<number>(
+  props.name,
+  (value) => value < 0,
+  {
+    initialValue: 0
+  }
+)
+</script>
+<style scoped lang="scss"></style>

--- a/packages/core/src/components/inputs/CurrencyInput/useCurrencyFormat.spec.ts
+++ b/packages/core/src/components/inputs/CurrencyInput/useCurrencyFormat.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { useCurrencyFormat } from '@core/components/inputs/CurrencyInput/useCurrencyFormat'
+
+describe('useCurrencyFormat', () => {
+  it.each([
+    { given: 0, expected: '00,00' },
+    { given: 1, expected: '00,01' },
+    { given: 12, expected: '00,12' },
+    { given: 123, expected: '01,23' },
+    { given: 1234, expected: '12,34' },
+    { given: 12345, expected: '123,45' }
+  ])(
+    'toEuroStringFromCentNumber - returns $expected if $given is given',
+    ({ given, expected }) => {
+      const { toEuroStringFromCentNumber } = useCurrencyFormat()
+      expect(toEuroStringFromCentNumber(given)).toBe(expected)
+    }
+  )
+
+  it.each([
+    { given: '', expected: '00,00' },
+    { given: '0', expected: '00,00' },
+    { given: '1', expected: '00,01' },
+    { given: '12', expected: '00,12' },
+    { given: '123', expected: '01,23' },
+    { given: '1234', expected: '12,34' },
+    { given: '12345', expected: '123,45' }
+  ])(
+    'toEuroStringFromCentString - returns $expected if $given is given',
+    ({ given, expected }) => {
+      const { toEuroStringFromCentString } = useCurrencyFormat()
+      expect(toEuroStringFromCentString(given)).toBe(expected)
+    }
+  )
+})

--- a/packages/core/src/components/inputs/CurrencyInput/useCurrencyFormat.ts
+++ b/packages/core/src/components/inputs/CurrencyInput/useCurrencyFormat.ts
@@ -1,0 +1,40 @@
+export function useCurrencyFormat() {
+  const INITIAL_VALUE_SIZE = 4
+
+  /**
+   * Fills a string with zeros to a fixed size
+   * @param value The string to fill with zeros
+   */
+  const _fillWithZeros = (value: string) => {
+    const missingZeros = INITIAL_VALUE_SIZE - value.length
+    if (missingZeros <= 0) {
+      return value
+    }
+    return '0'.repeat(missingZeros) + value
+  }
+
+  /**
+   * Formats a string of cents to a currency string
+   *
+   * @param centsString The string of cents (e.g. '1234' for 12,34€)
+   */
+  const toEuroStringFromCentString = (centsString: string) => {
+    const filledValue = _fillWithZeros(centsString)
+    return filledValue.slice(0, -2) + ',' + filledValue.slice(-2)
+  }
+
+  /**
+   * Converts a number of cents to a string representation of euros
+   *
+   * @param cents The number of cents (e.g. 234 for 02,34€)
+   */
+  const toEuroStringFromCentNumber = (cents: number) => {
+    const string = cents.toString()
+    return toEuroStringFromCentString(string)
+  }
+
+  return {
+    toEuroStringFromCentString,
+    toEuroStringFromCentNumber
+  }
+}

--- a/packages/core/src/components/inputs/index.ts
+++ b/packages/core/src/components/inputs/index.ts
@@ -3,6 +3,7 @@ import BaseInputV2 from '@core/components/inputs/BaseInputV2/BaseInputV2.vue'
 import BaseInputWrapper from '@core/components/inputs/BaseInputWrapper/BaseInputWrapper.vue'
 import BaseSelect from '@core/components/inputs/BaseSelect/BaseSelect.vue'
 import CheckboxInput from '@core/components/inputs/CheckboxInput/CheckboxInput.vue'
+import CurrencyInput from '@core/components/inputs/CurrencyInput/CurrencyInput.vue'
 import DateTimeInput from '@core/components/inputs/DateTimeInput/DateTimeInput.vue'
 import ImageInputWrapper from '@core/components/inputs/ImpageInputWrapper/ImageInputWrapper.vue'
 import LocationCoordinateSelect from '@core/components/inputs/LocationCoordinateSelect/LocationCoordinateSelect.vue'
@@ -18,6 +19,7 @@ export {
   BaseInputWrapper,
   BaseSelect,
   CheckboxInput,
+  CurrencyInput,
   DateTimeInput,
   ImageInputWrapper,
   LocationCoordinateSelect,


### PR DESCRIPTION
Adds a new input field called `CurrencyInput` that handles user input for currency values. The user can input its amount in cent. The cent string is converted into a cent number. This input should not have the problems with float cause it only returns a int number and represent the float as string.