### PR TITLE
Control saveDashboardModal display from parent

### DIFF
--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.spec.ts
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.spec.ts
@@ -29,7 +29,7 @@ describe('ConfigurableDashboard.vue', () => {
         dashboardConfigurationOptions: [],
         selectedDashboardConfiguration: undefined,
         showSaveModal: false,
-        showModalError: false
+        saveModalError: undefined
       }
     })
   })

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.spec.ts
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.spec.ts
@@ -27,7 +27,9 @@ describe('ConfigurableDashboard.vue', () => {
         availableWidgets: new Map(),
         dashboardConfig: [],
         dashboardConfigurationOptions: [],
-        selectedDashboardConfiguration: undefined
+        selectedDashboardConfiguration: undefined,
+        showSaveModal: false,
+        showModalError: false
       }
     })
   })

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.stories.ts
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.stories.ts
@@ -42,7 +42,7 @@ export const Default: Story = {
   }),
   args: {
     editMode: false,
-    showSaveModalError: false,
+    saveModalError: undefined,
     showSaveModal: false,
     availableWidgets: new Map<string, WidgetSetting>([
       ['widget1', TEMPLATE_WIDGET_WRAPPER],

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.stories.ts
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.stories.ts
@@ -39,6 +39,8 @@ export const Default: Story = {
   }),
   args: {
     editMode: false,
+    showModalErrors: false,
+    showSaveModal: false,
     availableWidgets: new Map<string, WidgetSetting>([
       ['widget1', TEMPLATE_WIDGET_WRAPPER],
       ['widget2', IFRAME_WIDGET_WRAPPER],

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.stories.ts
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.stories.ts
@@ -39,7 +39,7 @@ export const Default: Story = {
   }),
   args: {
     editMode: false,
-    showModalErrors: false,
+    showSaveModalError: false,
     showSaveModal: false,
     availableWidgets: new Map<string, WidgetSetting>([
       ['widget1', TEMPLATE_WIDGET_WRAPPER],

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
@@ -22,7 +22,7 @@
     >
       <SaveDashboardModal
         v-if="showSaveModal"
-        :show-error="showSaveModalError"
+        :error="saveModalError"
         @confirm-save="onConfirmSave"
       />
     </DismissibleModal>
@@ -72,7 +72,7 @@ const showSaveModal = defineModel<boolean>('showSaveModal')
 /**
  * A flag that indicates if an error should be displayed in the save modal
  */
-const showSaveModalError = defineModel<boolean>('showSaveModalError')
+const saveModalError = defineModel<Error | undefined>('saveModalError')
 /**
  * Selected dashboard configuration
  */
@@ -115,7 +115,7 @@ const onCancelEdit = () => {
   editMode.value = false
   dashboardConfig.value = currentConfig.value
   showSaveModal.value = false
-  showSaveModalError.value = false
+  saveModalError.value = undefined
 }
 
 const onDeleteDashboardConfiguration = () => {

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
@@ -92,7 +92,6 @@ const dashboardConfig = defineModel<WidgetConfiguration[]>('dashboardConfig', {
  */
 const currentConfig = ref(dashboardConfig.value)
 const editMode = ref<boolean>(false)
-const showSaveModal = ref(false)
 const showDeleteModal = ref<boolean>(false)
 const selectedDashboardConfigurationName = computed(() => {
   const config = props.dashboardConfigurationOptions.find(

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
@@ -16,7 +16,7 @@
       :edit-mode="editMode"
     />
     <DismissibleModal
-      v-model:modalDisplayed="showDismissibleModal"
+      v-model:modalDisplayed="localShowSaveModal"
       class="basic-modal"
     >
       <SaveDashboardModal
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts" setup>
-import { nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { WidgetComponentWrapper } from '@/models/widgetComponentWrapper'
 import { WidgetConfiguration } from '@/models/widgetConfiguration'
 import { GridWidget } from '@/models/gridWidget'
@@ -42,7 +42,7 @@ const props = defineProps<{
   /**
    * A flag that indicates if save modal should be displayed
    */
-  showSaveModal: { type: boolean; default: false }
+  showSaveModal: boolean
   /**
    * A flag that indicates if an error should be displayed in the save modal
    */
@@ -58,9 +58,7 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{
   (e: 'prepareSave'): void
-  /**
-   * Event that is emitted when the dashboard configuration is saved
-   */
+  (e: 'update:showSaveModal', value: boolean): void
   (e: 'save', dashboardConfig: WidgetConfiguration[], name: string): void
 }>()
 /**
@@ -83,10 +81,12 @@ const dashboardConfig = defineModel<WidgetConfiguration[]>('dashboardConfig', {
 const currentConfig = ref(dashboardConfig.value)
 const editMode = ref<boolean>(false)
 // separated from showSaveModal to avoid prop/v-model
-const showDismissibleModal = ref(props.showSaveModal)
+const localShowSaveModal = computed({
+  get: () => props.showSaveModal,
+  set: (value) => emit('update:showSaveModal', value)
+})
 
 const prepareSave = () => {
-  // showSaveModal.value = true
   emit('prepareSave')
 }
 
@@ -123,13 +123,6 @@ watch(editMode, (isEditMode) => {
     currentConfig.value = dashboardConfig.value
   }
 })
-
-watch(
-  () => props.showSaveModal,
-  (newVal) => {
-    showDismissibleModal.value = newVal
-  }
-)
 </script>
 
 <style scoped>

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
@@ -21,7 +21,7 @@
     >
       <SaveDashboardModal
         v-if="showSaveModal"
-        :show-error="showModalError"
+        :show-error="localShowModalError"
         @confirm-save="onConfirmSave"
       />
     </DismissibleModal>
@@ -57,8 +57,8 @@ const props = defineProps<{
   dashboardConfigurationOptions: Array<{ id: string; name: string }>
 }>()
 const emit = defineEmits<{
-  (e: 'prepareSave'): void
   (e: 'update:showSaveModal', value: boolean): void
+  (e: 'update:showModalError', value: boolean): void
   (e: 'save', dashboardConfig: WidgetConfiguration[], name: string): void
 }>()
 /**
@@ -80,14 +80,19 @@ const dashboardConfig = defineModel<WidgetConfiguration[]>('dashboardConfig', {
  */
 const currentConfig = ref(dashboardConfig.value)
 const editMode = ref<boolean>(false)
-// separated from showSaveModal to avoid prop/v-model
+
 const localShowSaveModal = computed({
   get: () => props.showSaveModal,
   set: (value) => emit('update:showSaveModal', value)
 })
 
+const localShowModalError = computed({
+  get: () => props.showModalError,
+  set: (value) => emit('update:showModalError', value)
+})
+
 const prepareSave = () => {
-  emit('prepareSave')
+  localShowSaveModal.value = true
 }
 
 const onConfirmSave = (name: string) => {
@@ -99,6 +104,8 @@ const onConfirmSave = (name: string) => {
 const onCancelEdit = () => {
   editMode.value = false
   dashboardConfig.value = currentConfig.value
+  localShowSaveModal.value = false
+  localShowModalError.value = false
 }
 
 const onAddWidget = async (widgetKey: string) => {

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
@@ -15,8 +15,15 @@
       v-model:widget-configs="dashboardConfig"
       :edit-mode="editMode"
     />
-    <DismissibleModal v-model:modalDisplayed="showModal" class="basic-modal">
-      <SaveDashboardModal v-if="showModal" @confirm-save="onConfirmSave" />
+    <DismissibleModal
+      v-model:modalDisplayed="showDismissibleModal"
+      class="basic-modal"
+    >
+      <SaveDashboardModal
+        v-if="showSaveModal"
+        :show-error="showModalError"
+        @confirm-save="onConfirmSave"
+      />
     </DismissibleModal>
   </div>
 </template>
@@ -31,7 +38,15 @@ import DynamicGrid from '@/components/DynamicGrid/DynamicGrid.vue'
 import { DismissibleModal } from '@lion5/component-library'
 import SaveDashboardModal from '@/components/SaveDashboardModal/SaveDashboardModal.vue'
 
-defineProps<{
+const props = defineProps<{
+  /**
+   * A flag that indicates if save modal should be displayed
+   */
+  showSaveModal: { type: boolean; default: false }
+  /**
+   * A flag that indicates if an error should be displayed in the save modal
+   */
+  showModalError: boolean
   /**
    * A map of widgets that can be added to the dashboard
    */
@@ -42,6 +57,10 @@ defineProps<{
   dashboardConfigurationOptions: Array<{ id: string; name: string }>
 }>()
 const emit = defineEmits<{
+  (e: 'prepareSave'): void
+  /**
+   * Event that is emitted when the dashboard configuration is saved
+   */
   (e: 'save', dashboardConfig: WidgetConfiguration[], name: string): void
 }>()
 /**
@@ -63,17 +82,18 @@ const dashboardConfig = defineModel<WidgetConfiguration[]>('dashboardConfig', {
  */
 const currentConfig = ref(dashboardConfig.value)
 const editMode = ref<boolean>(false)
-const showModal = ref(false)
+// separated from showSaveModal to avoid prop/v-model
+const showDismissibleModal = ref(props.showSaveModal)
 
 const prepareSave = () => {
-  showModal.value = true
+  // showSaveModal.value = true
+  emit('prepareSave')
 }
 
 const onConfirmSave = (name: string) => {
   editMode.value = false
   currentConfig.value = dashboardConfig.value
   emit('save', dashboardConfig.value, name)
-  showModal.value = false
 }
 
 const onCancelEdit = () => {
@@ -103,6 +123,13 @@ watch(editMode, (isEditMode) => {
     currentConfig.value = dashboardConfig.value
   }
 })
+
+watch(
+  () => props.showSaveModal,
+  (newVal) => {
+    showDismissibleModal.value = newVal
+  }
+)
 </script>
 
 <style scoped>

--- a/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
+++ b/packages/gridstack/src/components/ConfigurableDashboard/ConfigurableDashboard.vue
@@ -16,12 +16,12 @@
       :edit-mode="editMode"
     />
     <DismissibleModal
-      v-model:modalDisplayed="localShowSaveModal"
+      v-model:modalDisplayed="showSaveModal"
       class="basic-modal"
     >
       <SaveDashboardModal
         v-if="showSaveModal"
-        :show-error="localShowModalError"
+        :show-error="showSaveModalError"
         @confirm-save="onConfirmSave"
       />
     </DismissibleModal>
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, ref, watch } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { WidgetComponentWrapper } from '@/models/widgetComponentWrapper'
 import { WidgetConfiguration } from '@/models/widgetConfiguration'
 import { GridWidget } from '@/models/gridWidget'
@@ -38,15 +38,7 @@ import DynamicGrid from '@/components/DynamicGrid/DynamicGrid.vue'
 import { DismissibleModal } from '@lion5/component-library'
 import SaveDashboardModal from '@/components/SaveDashboardModal/SaveDashboardModal.vue'
 
-const props = defineProps<{
-  /**
-   * A flag that indicates if save modal should be displayed
-   */
-  showSaveModal: boolean
-  /**
-   * A flag that indicates if an error should be displayed in the save modal
-   */
-  showModalError: boolean
+defineProps<{
   /**
    * A map of widgets that can be added to the dashboard
    */
@@ -57,10 +49,17 @@ const props = defineProps<{
   dashboardConfigurationOptions: Array<{ id: string; name: string }>
 }>()
 const emit = defineEmits<{
-  (e: 'update:showSaveModal', value: boolean): void
-  (e: 'update:showModalError', value: boolean): void
   (e: 'save', dashboardConfig: WidgetConfiguration[], name: string): void
 }>()
+
+/**
+ * A flag that indicates if save modal should be displayed
+ */
+const showSaveModal = defineModel<boolean>('showSaveModal')
+/**
+ * A flag that indicates if an error should be displayed in the save modal
+ */
+const showSaveModalError = defineModel<boolean>('showSaveModalError')
 /**
  * Selected dashboard configuration
  */
@@ -81,18 +80,8 @@ const dashboardConfig = defineModel<WidgetConfiguration[]>('dashboardConfig', {
 const currentConfig = ref(dashboardConfig.value)
 const editMode = ref<boolean>(false)
 
-const localShowSaveModal = computed({
-  get: () => props.showSaveModal,
-  set: (value) => emit('update:showSaveModal', value)
-})
-
-const localShowModalError = computed({
-  get: () => props.showModalError,
-  set: (value) => emit('update:showModalError', value)
-})
-
 const prepareSave = () => {
-  localShowSaveModal.value = true
+  showSaveModal.value = true
 }
 
 const onConfirmSave = (name: string) => {
@@ -104,8 +93,8 @@ const onConfirmSave = (name: string) => {
 const onCancelEdit = () => {
   editMode.value = false
   dashboardConfig.value = currentConfig.value
-  localShowSaveModal.value = false
-  localShowModalError.value = false
+  showSaveModal.value = false
+  showSaveModalError.value = false
 }
 
 const onAddWidget = async (widgetKey: string) => {

--- a/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
+++ b/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
@@ -11,7 +11,7 @@
       name="name"
       class="base-input"
     />
-    <ErrorBox class="error-message" :error="nameError" />
+    <ErrorBox class="error-message" :error="props.error" />
 
     <BaseButton :disabled="!name" @click="submit" class="save-button">
       Speichern
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, toRef } from 'vue'
+import { ref, computed } from 'vue'
 import { BaseInputV2, BaseButton, ErrorBox } from '@lion5/component-library'
 
 const name = ref('')
@@ -28,11 +28,8 @@ const required = computed(() => ({
   required: (value: unknown) => !!value
 }))
 const props = defineProps({
-  showError: Boolean,
   error: Error
 })
-
-const nameError = toRef(props.error)
 
 const emit = defineEmits(['confirmSave'])
 

--- a/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
+++ b/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
@@ -11,6 +11,11 @@
       name="name"
       class="base-input"
     />
+    <div v-if="showError" class="error-message">
+      Fehler beim Speichern der Konfiguration. Konfiguration mit diesem Namen
+      existiert bereits.
+    </div>
+
     <BaseButton :disabled="!name" @click="submitAndClose" class="save-button">
       Speichern
     </BaseButton>
@@ -25,7 +30,9 @@ const name = ref('')
 const required = computed(() => ({
   required: (value: unknown) => !!value
 }))
-
+defineProps({
+  showError: Boolean
+})
 const emit = defineEmits(['confirmSave'])
 
 const submitAndClose = () => {
@@ -52,5 +59,8 @@ const submitAndClose = () => {
 .header1,
 .header2 {
   min-width: 300px;
+}
+.error-message {
+  color: red;
 }
 </style>

--- a/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
+++ b/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
@@ -11,7 +11,7 @@
       name="name"
       class="base-input"
     />
-    <ErrorBox v-if="showError" class="error-message" :error="nameError" />
+    <ErrorBox class="error-message" :error="nameError" />
 
     <BaseButton :disabled="!name" @click="submit" class="save-button">
       Speichern
@@ -20,20 +20,19 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue'
+import { ref, computed, toRef } from 'vue'
 import { BaseInputV2, BaseButton, ErrorBox } from '@lion5/component-library'
 
 const name = ref('')
 const required = computed(() => ({
   required: (value: unknown) => !!value
 }))
-defineProps({
-  showError: Boolean
+const props = defineProps({
+  showError: Boolean,
+  error: Error
 })
 
-const nameError = new Error(
-  'Fehler beim Speichern der Konfiguration. Konfiguration mit diesem Namen existiert bereits.'
-)
+const nameError = toRef(props.error)
 
 const emit = defineEmits(['confirmSave'])
 

--- a/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
+++ b/packages/gridstack/src/components/SaveDashboardModal/SaveDashboardModal.vue
@@ -11,10 +11,7 @@
       name="name"
       class="base-input"
     />
-    <div v-if="showError" class="error-message">
-      Fehler beim Speichern der Konfiguration. Konfiguration mit diesem Namen
-      existiert bereits.
-    </div>
+    <ErrorBox v-if="showError" class="error-message" :error="nameError" />
 
     <BaseButton :disabled="!name" @click="submitAndClose" class="save-button">
       Speichern
@@ -24,7 +21,7 @@
 
 <script lang="ts" setup>
 import { ref, computed } from 'vue'
-import { BaseInputV2, BaseButton } from '@lion5/component-library'
+import { BaseInputV2, BaseButton, ErrorBox } from '@lion5/component-library'
 
 const name = ref('')
 const required = computed(() => ({
@@ -33,6 +30,11 @@ const required = computed(() => ({
 defineProps({
   showError: Boolean
 })
+
+const nameError = new Error(
+  'Fehler beim Speichern der Konfiguration. Konfiguration mit diesem Namen existiert bereits.'
+)
+
 const emit = defineEmits(['confirmSave'])
 
 const submitAndClose = () => {
@@ -59,8 +61,5 @@ const submitAndClose = () => {
 .header1,
 .header2 {
   min-width: 300px;
-}
-.error-message {
-  color: red;
 }
 </style>


### PR DESCRIPTION
Control saveDashboardModal display from parent so that modal only closes when a success API call is performed, and otherwise show an error message.