### PR TITLE
docs(boxes): :memo: document auto hide function

### DIFF
--- a/packages/core/src/components/boxes/Boxes.mdx
+++ b/packages/core/src/components/boxes/Boxes.mdx
@@ -18,7 +18,8 @@ The `InfoBox` should be used to display important information to the user
 <Story of={InfoBoxStories.Default} />
 
 ## Error Box
-The `ErrorBox` should be used to display global error or errors to the user
+The `ErrorBox` should be used to display global error or errors to the user.
+<strong>It will not be rendered if no error given!</strong>
 <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
   <Story of={ErrorBoxStories.SingleError} />
   <Story of={ErrorBoxStories.MultipleErrors} />

--- a/packages/core/src/components/boxes/ErrorBox/ErrorBox.stories.ts
+++ b/packages/core/src/components/boxes/ErrorBox/ErrorBox.stories.ts
@@ -1,13 +1,19 @@
 import ErrorBox from '../../boxes/ErrorBox/ErrorBox.vue'
 import { Meta, StoryObj } from '@storybook/vue3'
 
+/**
+ * The error box should be used to display global errors that are not tied to a specific input field.
+ * It can display a single error or multiple errors.
+ *
+ * **If both props (error and errors) are undefined or empty, the box will not be rendered!**
+ */
 export default {
   component: ErrorBox
 } as Meta<typeof ErrorBox>
 type Story = StoryObj<typeof ErrorBox>
 
 /**
- * If only one error is given. It displays the error inside the box as string.
+ * If only one error is given. It displays the error inside the box on a single line.
  */
 export const SingleError: Story = {
   args: {
@@ -15,6 +21,9 @@ export const SingleError: Story = {
   }
 }
 
+/**
+ * If multiple errors are given. It displays each error as a list item.
+ */
 export const MultipleErrors: Story = {
   args: {
     errors: [

--- a/packages/core/src/components/boxes/InfoBox/InfoBox.stories.ts
+++ b/packages/core/src/components/boxes/InfoBox/InfoBox.stories.ts
@@ -1,6 +1,11 @@
 import { Meta, StoryObj } from '@storybook/vue3'
 import InfoBox from './InfoBox.vue'
 
+/**
+ * The info box should be used to display important information to the user.
+ *
+ * **If the infoMessage is undefined or empty, the box will not be rendered!**
+ */
 const meta: Meta<typeof InfoBox> = {
   component: InfoBox
 }
@@ -23,6 +28,11 @@ export const Default: Story = {
   }
 }
 
+/**
+ * It is also possible to use slots to display custom content inside the box.
+ *
+ *  **Currently, it is required to set the infoMessage prop to, but it is not displayed. Problem tracked by https://github.com/lion5/component-library/issues/201**
+ */
 export const UseSlot: Story = {
   render: (args) => ({
     components: { InfoBox },


### PR DESCRIPTION
Adds infos about the auto hide functions of the info and error boxes. Try to improve the current docs of these components.