### PR TITLE
fix(DropDown): display drop down content also if element is active

### DIFF
--- a/packages/core/src/components/dropdown/DropDown/DropDown.vue
+++ b/packages/core/src/components/dropdown/DropDown/DropDown.vue
@@ -57,7 +57,8 @@ const onClick = () => {
 
   .trigger:focus ~ .dropdown-content,
   &:focus-within .dropdown-content,
-  .dropdown-content:focus-within {
+  .dropdown-content:focus-within,
+  .dropdown-content:active {
     display: flex;
   }
 }


### PR DESCRIPTION
Seems that if a user click a drop down item in safari the click event is not fired because the focus is left before. With adding the active pseudo class it seem to work now.