### PR TITLE
Refactor DropDownItem

### DIFF
--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.spec.ts
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import type { defineComponent } from 'vue'
 import DropDownItem from '@core/components/dropdown/DropDownItem/DropDownItem.vue'
 
@@ -8,13 +8,32 @@ describe('DropDownItem.vue', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    wrapper = mount(DropDownItem, { props: { label: 'defaultTestLabel' } })
+    wrapper = shallowMount(DropDownItem, {
+      props: {
+        label: 'defaultTestLabel'
+      },
+      slots: {
+        icon: '<span class="icon-slot">Icon</span>',
+        'busy-icon': '<span class="busy-icon-slot">Busy Icon</span>'
+      }
+    })
   })
   describe(':props', () => {
     it(':label - is displayed', async () => {
       const expectedLabel = 'testLabel'
       await wrapper.setProps({ label: expectedLabel })
-      expect(wrapper.find('button').text()).toBe(expectedLabel)
+      expect(wrapper.find('button').text()).toContain(expectedLabel)
+    })
+
+    it(':busy - displays icon slot by default (when busy is false)', async () => {
+      expect(wrapper.find('.icon-slot').exists()).toBe(true)
+      expect(wrapper.find('.busy-icon-slot').exists()).toBe(false)
+    })
+
+    it(':busy - displays busy-icon slot when busy is true', async () => {
+      await wrapper.setProps({ busy: true })
+      expect(wrapper.find('.icon-slot').exists()).toBe(false)
+      expect(wrapper.find('.busy-icon-slot').exists()).toBe(true)
     })
   })
 })

--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
@@ -1,17 +1,27 @@
 <template>
   <button v-bind="$attrs" class="drop-down-item">
-    <slot name="icon" />
+    <slot name="icon" v-if="!busy" />
+    <slot name="busy-icon" v-if="busy" />
     {{ label }}
   </button>
 </template>
 
 <script lang="ts" setup>
-defineProps<{
-  /**
-   * the dropdown items label. Displayed beside the icon
-   */
-  label: string
-}>()
+withDefaults(
+  defineProps<{
+    /**
+     * The dropdown item's label. Displayed beside the icon.
+     */
+    label: string
+    /**
+     * Indicates if the item is busy, affecting the displayed icon.
+     */
+    busy?: boolean
+  }>(),
+  {
+    busy: false
+  }
+)
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Replaces the default icon with a busy-icon when the item is busy, providing visual feedback to the user that an action is in progress.