### PR TITLE
add busy-icon to DropDownItem

### DIFF
--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.spec.ts
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import type { defineComponent } from 'vue'
 import DropDownItem from '@core/components/dropdown/DropDownItem/DropDownItem.vue'
 
@@ -8,13 +8,32 @@ describe('DropDownItem.vue', () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    wrapper = mount(DropDownItem, { props: { label: 'defaultTestLabel' } })
+    wrapper = shallowMount(DropDownItem, {
+      props: {
+        label: 'defaultTestLabel'
+      },
+      slots: {
+        icon: '<span class="icon-slot">Icon</span>',
+        'busy-icon': '<span class="busy-icon-slot">Busy Icon</span>'
+      }
+    })
   })
   describe(':props', () => {
     it(':label - is displayed', async () => {
       const expectedLabel = 'testLabel'
       await wrapper.setProps({ label: expectedLabel })
-      expect(wrapper.find('button').text()).toBe(expectedLabel)
+      expect(wrapper.find('button').text()).toContain(expectedLabel)
+    })
+
+    it(':busy - displays icon slot by default (when busy is false)', async () => {
+      expect(wrapper.find('.icon-slot').exists()).toBe(true)
+      expect(wrapper.find('.busy-icon-slot').exists()).toBe(false)
+    })
+
+    it(':busy - displays busy-icon slot when busy is true', async () => {
+      await wrapper.setProps({ busy: true })
+      expect(wrapper.find('.icon-slot').exists()).toBe(false)
+      expect(wrapper.find('.busy-icon-slot').exists()).toBe(true)
     })
   })
 })

--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
@@ -37,6 +37,7 @@ withDefaults(
   padding: var(--space-xs) var(--space-sm);
   cursor: pointer;
   outline: none;
+  align-items: center;
 
   &:hover,
   &:focus-within {

--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
@@ -1,17 +1,27 @@
 <template>
   <button v-bind="$attrs" class="drop-down-item">
-    <slot name="icon" />
+    <slot name="icon" v-if="!busy" />
+    <slot name="busy-icon" v-if="busy" />
     {{ label }}
   </button>
 </template>
 
 <script lang="ts" setup>
-defineProps<{
-  /**
-   * the dropdown items label. Displayed beside the icon
-   */
-  label: string
-}>()
+withDefaults(
+  defineProps<{
+    /**
+     * The dropdown item's label. Displayed beside the icon.
+     */
+    label: string
+    /**
+     * Indicates if the item is busy, affecting the displayed icon.
+     */
+    busy?: boolean
+  }>(),
+  {
+    busy: false
+  }
+)
 </script>
 
 <style lang="scss" scoped>

--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
@@ -1,12 +1,16 @@
 <template>
   <button v-bind="$attrs" class="drop-down-item">
     <slot name="icon" v-if="!busy" />
-    <slot name="busy-icon" v-if="busy" />
+    <slot name="busy-icon" v-if="busy">
+      <ArrowRotateLoadingAnimation />
+    </slot>
     {{ label }}
   </button>
 </template>
 
 <script lang="ts" setup>
+import ArrowRotateLoadingAnimation from '@core/components/icons/ArrowRotateLoadingAnimation.vue'
+
 withDefaults(
   defineProps<{
     /**

--- a/packages/core/src/components/icons/ArrowRotateLoadingAnimation.vue
+++ b/packages/core/src/components/icons/ArrowRotateLoadingAnimation.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="rotate-animation">
+    <BaseIcon icon="bi-arrow-repeat" />
+  </div>
+</template>
+<script lang="ts" setup>
+import BaseIcon from '@/components/BaseIcon.vue'
+</script>
+<style lang="scss" scoped>
+.rotate-animation {
+  animation: rotate 1s infinite linear;
+  line-height: 1;
+
+  .bi::before {
+    vertical-align: bottom;
+  }
+}
+
+@keyframes rotate {
+  0% {
+    rotate: 0deg;
+  }
+  100% {
+    rotate: 360deg;
+  }
+}
+</style>

--- a/packages/core/src/components/icons/ArrowRotateLoadingAnimation.vue
+++ b/packages/core/src/components/icons/ArrowRotateLoadingAnimation.vue
@@ -4,7 +4,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-import BaseIcon from '@/components/BaseIcon.vue'
+import BaseIcon from '@core/components/icons/BaseIcon.vue'
 </script>
 <style lang="scss" scoped>
 .rotate-animation {


### PR DESCRIPTION
Replaces the default icon with a busy-icon when the item is busy, providing visual feedback to the user that an action is in progress.