### PR TITLE
feat(DropDownItem): disable button if busy is set

### DIFF
--- a/packages/core/src/components/dropdown/DropDown/DropDown.stories.ts
+++ b/packages/core/src/components/dropdown/DropDown/DropDown.stories.ts
@@ -24,7 +24,7 @@ export const Text: Story = {
             </template>
           </DropDownItem>
           <DropDownItem label='Item 2' />
-          <DropDownItem label='Item 3' />
+          <DropDownItem label='Item 3' :busy="true" />
         </template>
       </DropDown>
       </div>

--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.spec.ts
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.spec.ts
@@ -35,5 +35,15 @@ describe('DropDownItem.vue', () => {
       expect(wrapper.find('.icon-slot').exists()).toBe(false)
       expect(wrapper.find('.busy-icon-slot').exists()).toBe(true)
     })
+
+    it(':busy - disable button if busy true', async () => {
+      await wrapper.setProps({ busy: true })
+      expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+    })
+
+    it(':busy - enable button if busy false', async () => {
+      await wrapper.setProps({ busy: false })
+      expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+    })
   })
 })

--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.stories.ts
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.stories.ts
@@ -13,23 +13,38 @@ export const Text: Story = {
   }
 }
 
-export const IconWithText: Story = {
-  render: (args: unknown) => ({
-    components: { DropDownItem, IconSettings },
-    setup() {
-      return { args }
-    },
-    template: `
-      <div style='width: fit-content'>
+const templateWithIcon = (args: unknown) => ({
+  components: { DropDownItem, IconSettings },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div style='width: fit-content'>
       <DropDownItem v-bind='args'>
         <template #icon>
           <IconSettings />
         </template>
       </DropDownItem>
-      </div>
-    `
-  }),
+      <DropDownItem v-bind='args'>
+        <template #icon>
+          <IconSettings />
+        </template>
+      </DropDownItem>
+    </div>
+  `
+})
+
+export const IconWithText: Story = {
+  render: templateWithIcon,
   args: {
     label: 'DropDown Item'
+  }
+}
+
+export const Busy: Story = {
+  render: templateWithIcon,
+  args: {
+    label: 'DropDown Item',
+    busy: true
   }
 }

--- a/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
+++ b/packages/core/src/components/dropdown/DropDownItem/DropDownItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <button v-bind="$attrs" class="drop-down-item">
+  <button v-bind="$attrs" class="drop-down-item" :disabled="busy">
     <slot name="icon" v-if="!busy" />
     <slot name="busy-icon" v-if="busy">
       <ArrowRotateLoadingAnimation />
@@ -46,6 +46,11 @@ withDefaults(
   &:hover,
   &:focus-within {
     background-color: var(--color-primary-300);
+  }
+
+  &:disabled {
+    cursor: progress;
+    color: var(--color-neutral-500);
   }
 }
 </style>


### PR DESCRIPTION
The dropdown button should be disabled if the state is busy so that it cannot be triggered twice.