### PR TITLE
Fix: base color overwrite

### DIFF
--- a/packages/core/.storybook/main.scss
+++ b/packages/core/.storybook/main.scss
@@ -1,38 +1,3 @@
 @use '../src/assets/style/reset.scss' as *;
 @use '../src/assets/style/variables/index.scss' as *;
 @use '../src/assets/style/icons.scss' as *;
-
-:root {
-  /* Overwrite light and dark theme */
-  --primary-hue: 200;
-  --primary-saturation: 100%;
-  --primary-lightness: 50%;
-
-  --success-hue: 110;
-  --success-saturation: 100%;
-
-  --danger-hue: 5;
-  --danger-saturation: 100%;
-
-  /* Overwrite light theme */
-  --light-primary-hue: 230;
-  --light-primary-saturation: 50%;
-  --light-primary-lightness: 50%;
-
-  --light-success-hue: 120;
-  --light-success-saturation: 120%;
-
-  --light-danger-hue: 5;
-  --light-danger-saturation: 5%;
-
-  /* Overwrite dark theme */
-  --dark-primary-hue: 50;
-  --dark-primary-saturation: 50%;
-  --dark-primary-lightness: 50%;
-
-  --dark-success-hue: 120;
-  --dark-success-saturation: 100%;
-
-  --dark-danger-hue: 5;
-  --dark-danger-saturation: 100%;
-}

--- a/packages/core/src/assets/style/variables/_color.scss
+++ b/packages/core/src/assets/style/variables/_color.scss
@@ -14,9 +14,12 @@
 
   /* Color Definitions */
   // Primary Color = Brand Color = Accent Color
-  --primary-hue: var(--light-primary-hue, 220);
-  --primary-saturation: var(--light-primary-saturation, 100%);
-  --primary-lightness: var(--light-primary-lightness, 50%); // To be able to define the primary color more precisely we need to set the lightness here
+  --_primary-hue-default: 220;
+  --_primary-saturation-default: 100%;
+  --_primary-lightness-default: 50%;
+  --primary-hue: var(--light-primary-hue, var(--_primary-hue-default));
+  --primary-saturation: var(--light-primary-saturation, var(--_primary-saturation-default));
+  --primary-lightness: var(--light-primary-lightness, var(--_primary-lightness-default)); // To be able to define the primary color more precisely we need to set the lightness here
 
   --color-primary-100: hsl(var(--primary-hue) var(--primary-saturation) var(--l-100));
   --color-primary-200: hsl(var(--primary-hue) var(--primary-saturation) var(--l-200));
@@ -28,8 +31,10 @@
   --color-primary-800: hsl(var(--primary-hue) var(--primary-saturation) var(--l-800));
   --color-primary-900: hsl(var(--primary-hue) var(--primary-saturation) var(--l-900));
 
-  --success-hue: var(--light-success-hue, 152.2);
-  --success-saturation: var(--light-success-saturation, 68.8%);
+  --_success-hue-default: 152.2;
+  --_success-saturation-default: 68.8%;
+  --success-hue: var(--light-success-hue, var(--_success-hue-default));
+  --success-saturation: var(--light-success-saturation, var(--_success-saturation-default));
   --color-success-100: hsl(var(--success-hue) var(--success-saturation) var(--l-100));
   --color-success-200: hsl(var(--success-hue) var(--success-saturation) var(--l-200));
   --color-success-300: hsl(var(--success-hue) var(--success-saturation) var(--l-300));
@@ -40,8 +45,10 @@
   --color-success-800: hsl(var(--success-hue) var(--success-saturation) var(--l-800));
   --color-success-900: hsl(var(--success-hue) var(--success-saturation) var(--l-900));
 
-  --danger-hue: var(--light-danger-hue, 354.3);
-  --danger-saturation: var(--light-danger-saturation, 70.5%);
+  --_danger-hue-default: 354.3;
+  --_danger-saturation-default: 100%;
+  --danger-hue: var(--light-danger-hue, var(--_danger-hue-default));
+  --danger-saturation: var(--light-danger-saturation, var(--_danger-saturation-default));
   --color-danger-100: hsl(var(--danger-hue) var(--danger-saturation) var(--l-100));
   --color-danger-200: hsl(var(--danger-hue) var(--danger-saturation) var(--l-200));
   --color-danger-300: hsl(var(--danger-hue) var(--danger-saturation) var(--l-300));
@@ -81,18 +88,19 @@
     --l-800: 93%;
     --l-900: 98%;
 
-    --primary-hue: var(--dark-primary-hue, var(--primary-hue));
-    --primary-saturation: var(--dark-primary-saturation, var(--primary-saturation));
-    --primary-lightness: var(--dark-primary-lightness, var(--primary-lightness));
-    --success-hue: var(--dark-success-hue, var(--success-hue));
-    --success-saturation: var(--dark-success-saturation, var(--success-saturation));
-    --danger-hue: var(--dark-danger-hue, var(--danger-hue));
-    --danger-saturation: var(--dark-danger-saturation, var(--danger-saturation));
+    --primary-hue: var(--dark-primary-hue, var(--_primary-hue-default));
+    --primary-saturation: var(--dark-primary-saturation, var(--_primary-saturation-default));
+    --primary-lightness: var(--dark-primary-lightness, var(--_primary-lightness-default));
+    --success-hue: var(--dark-success-hue, var(--_success-hue-default));
+    --success-saturation: var(--dark-success-saturation, var(--_success-saturation-default));
+    --danger-hue: var(--dark-danger-hue, var(--_danger-hue-default));
+    --danger-saturation: var(--dark-danger-saturation, var(--_danger-saturation-default));
 
     --color-white: #000;
     --color-black: #fff;
   }
 }
+
 // Special Colors
 :root {
   --color-primary: hsl(var(--primary-hue, 220) var(--primary-saturation, 30%) var(--primary-lightness, 40%));
@@ -101,7 +109,7 @@
 
   --color-success: var(--color-success-600);
   --color-success-surface: var(--color-success-100);
-  --color-success-hover:  var(--color-success-700);
+  --color-success-hover: var(--color-success-700);
 
   /**
   @deprecated use danger color instead

--- a/packages/core/src/components/boxes/ErrorBox/ErrorBox.vue
+++ b/packages/core/src/components/boxes/ErrorBox/ErrorBox.vue
@@ -38,7 +38,7 @@ const localErrors = computed(() => {
 </script>
 <style lang="scss" scoped>
 .error-box {
-  --box-background-color: var(--color-danger-surface-300);
+  --box-background-color: var(--color-danger-200);
 
   display: flex;
   gap: var(--space-sm);

--- a/packages/core/src/components/boxes/InfoBox/InfoBox.vue
+++ b/packages/core/src/components/boxes/InfoBox/InfoBox.vue
@@ -18,7 +18,7 @@ defineProps<{
 </script>
 <style lang="scss" scoped>
 .info-box {
-  --box-background-color: var(--color-primary-surface);
+  --box-background-color: var(--color-primary-200);
   --box-color: var(--color-font-1);
   i {
     margin-right: var(--space-sm);

--- a/packages/core/src/components/inputs/AddressInputValidated/AddressInputValidated.stories.ts
+++ b/packages/core/src/components/inputs/AddressInputValidated/AddressInputValidated.stories.ts
@@ -47,7 +47,7 @@ export const Filled: Story = {
 
 export const Required: Story = {
   args: {
-    name: 'input-with-error',
+    name: 'input-required',
     modelValue: new Address('An der Weberei 5', '96052', 'Bamberg'),
     validationRules: string().required()
   }

--- a/packages/core/src/components/inputs/AddressInputValidated/AddressInputValidated.vue
+++ b/packages/core/src/components/inputs/AddressInputValidated/AddressInputValidated.vue
@@ -16,7 +16,7 @@ withDefaults(
     validationRules?: RuleExpression<string>
   }>(),
   {
-    validationRules: ''
+    validationRules: undefined
   }
 )
 

--- a/packages/core/src/components/inputs/BaseInputV3Validated/BaseInputV3Validated.vue
+++ b/packages/core/src/components/inputs/BaseInputV3Validated/BaseInputV3Validated.vue
@@ -65,7 +65,7 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: T): void
 }>()
 
-const required = computed(() => (props.validationRules as Schema)?.spec.optional === false)
+const required = computed(() => (props.validationRules as Schema)?.spec?.optional === false)
 
 const { value, meta, handleBlur, errors } = useField<T>(() => props.name, props.validationRules, {
   syncVModel: true


### PR DESCRIPTION
Dark colors overwrite colors in a weird way. Root cause was a cyclic definition for the primary hsl attributes.