### PR TITLE
show validation errors as soon as user interact with the field

### DIFF
--- a/packages/core/src/components/inputs/EuroInputValidated/EuroInputValidated.vue
+++ b/packages/core/src/components/inputs/EuroInputValidated/EuroInputValidated.vue
@@ -71,6 +71,8 @@ const setAsEuroValue = (event: InputEvent) => {
   }
   const euroValue = parseInt(cleanedValue)
   syncValueWithElements(euroValue, event.target as HTMLInputElement)
+
+  meta.touched = true
 }
 
 const syncValueWithElements = (newValue: number, target: HTMLInputElement) => {

--- a/packages/core/src/components/inputs/NumberInputValidated/NumberInputValidated.vue
+++ b/packages/core/src/components/inputs/NumberInputValidated/NumberInputValidated.vue
@@ -50,6 +50,8 @@ const handleInput = (inputValue?: string) => {
     return
   }
   setValue(Number(inputValue))
+
+  meta.touched = true
 }
 
 const required = computed(() => (props.validationRules as Schema)?.spec.optional === false)


### PR DESCRIPTION
When a user enters an invalid value for the first time, the error message doesn’t appear immediately. Instead, it only shows up after the user clicks outside the field. This happens because VeeValidate waits for the field to be "touched" (blurred) before displaying validation errors. After the first blur, errors appear instantly on any further invalid input.