### PR TITLE
Feat: EditableEntityCard with optional readOnly prop

### DIFF
--- a/packages/core/src/components/cards/EditableEntityCard/EditableEntityCard.spec.ts
+++ b/packages/core/src/components/cards/EditableEntityCard/EditableEntityCard.spec.ts
@@ -51,6 +51,17 @@ describe('EditableEntityCard.vue', () => {
       expect(wrapper.find('.form-content').exists()).toBe(true)
       expect(wrapper.find('.info-content').exists()).toBe(false)
     })
+    it(':readOnly - hides the edit button if true', async () => {
+      await wrapper.setProps({ readOnly: true, modelValue: false })
+
+      expect(wrapper.find('.edit-button').exists()).toBe(false)
+    })
+
+    it(':readOnly - shows the edit button if false', async () => {
+      await wrapper.setProps({ readOnly: false, modelValue: false })
+
+      expect(wrapper.find('.edit-button').exists()).toBe(true)
+    })
   })
   describe('@events', () => {
     it('@click - emits edit mode true', async () => {

--- a/packages/core/src/components/cards/EditableEntityCard/EditableEntityCard.stories.ts
+++ b/packages/core/src/components/cards/EditableEntityCard/EditableEntityCard.stories.ts
@@ -27,3 +27,10 @@ export const Default: Story = {
     title: 'Topic'
   }
 }
+
+export const ReadOnly: Story = {
+  args: {
+    title: 'Topic',
+    readOnly: true
+  }
+}

--- a/packages/core/src/components/cards/EditableEntityCard/EditableEntityCard.vue
+++ b/packages/core/src/components/cards/EditableEntityCard/EditableEntityCard.vue
@@ -8,22 +8,30 @@ import IconButton from '@core/components/buttons/IconButton/IconButton.vue'
  */
 const editMode = defineModel<boolean>({ required: true })
 
-defineProps<{
+const props = defineProps({
   /**
    * The title of the card (the entity name).
    */
-  title: string
-}>()
-
-
+  title: {
+    type: String,
+    required: true
+  },
+  /**
+   * If true, editing is disabled (the edit pencil icon won't show).
+   */
+  readOnly: {
+    type: Boolean,
+    default: false
+  }
+})
 </script>
 
 <template>
   <BaseCard class="editable-entity-card">
-    <h2>{{ title }}</h2>
+    <h2>{{ props.title }}</h2>
     <div class="top-end-icon">
       <IconButton
-        v-if="!editMode"
+        v-if="!editMode && !props.readOnly"
         class="edit-button"
         @click="editMode = true"
       >


### PR DESCRIPTION
Add `readOnly` prop to EditableEntityCard with default value `false`