### PR TITLE
fix: add margin right variable to DropDown

### DIFF
--- a/packages/core/src/components/dropdown/DropDown/DropDown.stories.ts
+++ b/packages/core/src/components/dropdown/DropDown/DropDown.stories.ts
@@ -3,9 +3,14 @@ import DropDownItem from '../DropDownItem/DropDownItem.vue'
 import IconSettings from '../../icons/IconSettings.vue'
 import DropDown from './DropDown.vue'
 
+/**
+ * DropDown can be configured via following css custom props
+ * - `--dropdown-margin-right` to define the right margin of the DropDown-Content. Default is zero.
+ */
+
 export default {
   component: DropDown,
-  title: 'Navigation Components/DropDown/DropDown',
+  title: 'Navigation Components/DropDown/DropDown'
 } as Meta<typeof DropDown>
 type Story = StoryObj<typeof DropDown>
 
@@ -17,17 +22,17 @@ export const Text: Story = {
     },
     template: `
       <div style='display: grid; place-content: start end; height: 100px'>
-      <DropDown>
-        <template #dropDownContent>
-          <DropDownItem label='Item 1'>
-            <template #icon>
-              <IconSettings />
-            </template>
-          </DropDownItem>
-          <DropDownItem label='Item 2' />
-          <DropDownItem label='Item 3' :busy="true" />
-        </template>
-      </DropDown>
+        <DropDown>
+          <template #dropDownContent>
+            <DropDownItem label='Item 1'>
+              <template #icon>
+                <IconSettings />
+              </template>
+            </DropDownItem>
+            <DropDownItem label='Item 2' />
+            <DropDownItem label='Item 3' :busy="true" />
+          </template>
+        </DropDown>
       </div>
     `
   }),

--- a/packages/core/src/components/dropdown/DropDown/DropDown.stories.ts
+++ b/packages/core/src/components/dropdown/DropDown/DropDown.stories.ts
@@ -3,11 +3,6 @@ import DropDownItem from '../DropDownItem/DropDownItem.vue'
 import IconSettings from '../../icons/IconSettings.vue'
 import DropDown from './DropDown.vue'
 
-/**
- * DropDown can be configured via following css custom props
- * - `--dropdown-margin-right` to define the right margin of the DropDown-Content. Default is zero.
- */
-
 export default {
   component: DropDown,
   title: 'Navigation Components/DropDown/DropDown'

--- a/packages/core/src/components/dropdown/DropDown/DropDown.vue
+++ b/packages/core/src/components/dropdown/DropDown/DropDown.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="drop-down">
-    <IconButton class="trigger" ref="triggerButton" @click="onClick">
+    <IconButton ref="triggerButton" class="trigger" @click="onClick">
       <slot name="dropDownIcon">
         <IconThreeDotsMenu />
       </slot>
@@ -38,12 +38,13 @@ const onClick = () => {
   }
 
   .dropdown-content {
+    --_dropdown-margin-right: var(--dropdown-margin-right, 0);
     position: absolute;
     right: var(--anchor-right, 0);
     top: var(--anchor-top, calc(100% + var(--space-300)));
     bottom: var(--anchor-bottom, unset);
     left: var(--anchor-left, unset);
-    margin-right: var(--font-size-5);
+    margin-right: var(--_dropdown-margin-right);
     width: max-content;
     display: none;
     flex-direction: column;

--- a/packages/core/src/components/dropdown/DropDown/DropDown.vue
+++ b/packages/core/src/components/dropdown/DropDown/DropDown.vue
@@ -38,13 +38,11 @@ const onClick = () => {
   }
 
   .dropdown-content {
-    --_dropdown-margin-right: var(--dropdown-margin-right, 0);
     position: absolute;
     right: var(--anchor-right, 0);
     top: var(--anchor-top, calc(100% + var(--space-300)));
     bottom: var(--anchor-bottom, unset);
     left: var(--anchor-left, unset);
-    margin-right: var(--_dropdown-margin-right);
     width: max-content;
     display: none;
     flex-direction: column;


### PR DESCRIPTION
The DropDown-Content has a small margin to the right in the Bamberg Gutschein project. This is because it has the style margin-right: var(--font-size-5); declared. This isn't visible in the component library because font-size-5 is not declared as a variable in it! We should remove it so it doesn't affect the projects. We can maybe declare a variable to define the margin to the right, but the default value should be set to 0.