### PR TITLE
fix(CentInputValidated): fix incorrect deletion behaviour in Firefox

### DIFF
--- a/packages/core/src/components/inputs/CentInputValidated/CentInputValidated.spec.ts
+++ b/packages/core/src/components/inputs/CentInputValidated/CentInputValidated.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import type { defineComponent } from 'vue'
 import CentInput from './CentInputValidated.vue'
@@ -44,6 +44,54 @@ describe('CentInput.vue', () => {
   })
 
   describe('@events', () => {
+    it('@beforeinput - calls preventDefault for non-digit characters', async () => {
+      const input = wrapper.find('input')
+      const event = new InputEvent('beforeinput', {
+        data: 'a',
+        bubbles: true,
+        cancelable: true
+      })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      input.element.dispatchEvent(event)
+      await flushPromises()
+
+      expect(preventDefaultSpy).toHaveBeenCalledOnce()
+    })
+    it('@beforeinput - calls preventDefault for leading zero when value is empty', async () => {
+      const localWrapper = mount(CentInput, {
+        props: {
+          name: 'name',
+          cents: null as unknown as number
+        }
+      })
+      const input = localWrapper.find('input')
+      const event = new InputEvent('beforeinput', {
+        data: '0',
+        bubbles: true,
+        cancelable: true
+      })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      input.element.dispatchEvent(event)
+      await flushPromises()
+
+      expect(preventDefaultSpy).toHaveBeenCalledOnce()
+    })
+    it('@beforeinput - does not call preventDefault for delete inputType', async () => {
+      const input = wrapper.find('input')
+      const event = new InputEvent('beforeinput', {
+        inputType: 'deleteContentBackward',
+        bubbles: true,
+        cancelable: true
+      })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      input.element.dispatchEvent(event)
+      await flushPromises()
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+    })
     it('@update:cents - does not emit if user input 0 at first position', async () => {
       const input = wrapper.find('input')
       await input.trigger('input', { data: '0' })
@@ -79,6 +127,16 @@ describe('CentInput.vue', () => {
       expect(wrapper.emitted('update:cents').at(2)).toStrictEqual([123])
       expect(wrapper.find('input').element.value).toBe('01,23')
     })
+    it('@update:cents - sanitizes mixed pasted text and emits only digits', async () => {
+      const input = wrapper.find('input')
+      await input.trigger('input', { data: 'a1b2' })
+      await flushPromises()
+
+      expect(wrapper.emitted()).toHaveProperty('update:cents')
+      expect(wrapper.emitted('update:cents')).toHaveLength(1)
+      expect(wrapper.emitted('update:cents').at(0)).toStrictEqual([12])
+      expect(wrapper.find('input').element.value).toBe('00,12')
+    })
     it('@update:cents - emit 120 if user input 0 at last position of 00,12 €', async () => {
       const input = wrapper.find('input')
       await input.trigger('input', { data: '1' })
@@ -103,6 +161,23 @@ describe('CentInput.vue', () => {
       expect(wrapper.emitted('update:cents')).toHaveLength(1)
       expect(wrapper.emitted('update:cents').at(0)).toStrictEqual([12])
       expect(wrapper.find('input').element.value).toBe('00,12')
+    })
+    it('@update:cents - calls preventDefault when user deletes the last position', async () => {
+      await wrapper.setProps({ cents: 123 })
+      await flushPromises()
+
+      const input = wrapper.find('input')
+      const event = new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        bubbles: true,
+        cancelable: true
+      })
+      const preventDefaultSpy = vi.spyOn(event, 'preventDefault')
+
+      input.element.dispatchEvent(event)
+      await flushPromises()
+
+      expect(preventDefaultSpy).toHaveBeenCalledOnce()
     })
     it('@update:cents - emit 0 if last position deleted', async () => {
       await wrapper.setProps({ cents: 1 })

--- a/packages/core/src/components/inputs/CentInputValidated/CentInputValidated.vue
+++ b/packages/core/src/components/inputs/CentInputValidated/CentInputValidated.vue
@@ -9,6 +9,7 @@
     :required="required"
     type="tel"
     @blur="handleBlur"
+    @beforeinput="onBeforeInput"
     @input="onRawInput"
     @keydown.delete="onDelete"
   >
@@ -61,16 +62,59 @@ const displayedCurrencyValue = ref<string>('00,00')
 const onRawInput = (event: Event) => {
   onInput(event as InputEvent)
 }
+
+/**
+ * Guards the input before the browser writes the character into the field.
+ * Prevents invalid input early via `event.preventDefault()` so that the DOM value
+ * never needs to be manually reverted afterwards (which is unreliable in Firefox).
+ *
+ * Allows: digit characters (0–9), delete-type operations, and IME composition events.
+ * Blocks: any non-digit character and a standalone zero when the field is still empty
+ *         (which would otherwise produce a leading zero in the cent string).
+ *
+ * @param event The `beforeinput` event fired before the browser updates the input value.
+ */
+const onBeforeInput = (event: InputEvent) => {
+  if (event.isComposing || (event.inputType && event.inputType.startsWith('delete'))) {
+    return
+  }
+
+  const rawInput = event.data ?? ''
+  const isDigitInput = /^\d+$/.test(rawInput)
+  if (!isDigitInput) {
+    event.preventDefault()
+    return
+  }
+
+  const isAttemptingLeadingZero = internalValue.value.length === 0 && /^0+$/.test(rawInput)
+  if (isAttemptingLeadingZero) {
+    event.preventDefault()
+  }
+}
+
+/**
+ * Processes the accepted input after the browser has written it to the field.
+ * Acts as a secondary sanitization layer for cases such as pasted text that may
+ * slip past `onBeforeInput`.
+ * Strips all non-digit characters and removes leading zeros when the internal
+ * value is still empty, then delegates to `onAdd`.
+ *
+ * @param event The `input` event fired after the browser updates the input value.
+ */
 const onInput = (event: InputEvent) => {
-  if (event.data == null || event.data.match(/[0-9]/) == null) {
-    ;(event.target as HTMLInputElement).value = displayedCurrencyValue.value
+  const rawInput = event.data ?? ''
+  const digitsOnly = rawInput.replace(/\D/g, '')
+  if (digitsOnly.length === 0) {
     return
   }
-  if (internalValue.value.length === 0 && event.data === '0') {
-    ;(event.target as HTMLInputElement).value = displayedCurrencyValue.value
+
+  const sanitizedInput =
+    internalValue.value.length === 0 ? digitsOnly.replace(/^0+/, '') : digitsOnly
+  if (sanitizedInput.length === 0) {
     return
   }
-  onAdd(event.data)
+
+  onAdd(sanitizedInput)
 }
 
 /**
@@ -91,10 +135,11 @@ const onAdd = (inputValue: string) => {
  * Sets the displayed currency value to the formatted internal value.
  * Sets the value of the field as a number.
  */
-const onDelete = () => {
+const onDelete = (event: KeyboardEvent) => {
   if (internalValue.value.length === 0) {
     return
   }
+  event.preventDefault()
   internalValue.value = internalValue.value.slice(0, -1)
   value.value = parseInt(internalValue.value || '0')
 }


### PR DESCRIPTION
# Description

With Firefox, two problems existed:
- deletion would hide the last digit. 
- non-digit characters could be added to the field (would be displayed, but would not actually be represented in the value)

Both problems should now be fixed.

Fixes/Closes #404 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Make sure the documentation can be built (see command above - will be verified by CI as well)
